### PR TITLE
Refactor FileContent to Content

### DIFF
--- a/content.go
+++ b/content.go
@@ -6,7 +6,7 @@ import (
 	"weak"
 )
 
-type FileContent interface {
+type Content interface {
 	Data() (*[]byte, error)
 	Close() error
 	SetGenerator(func() (io.ReadCloser, error))
@@ -64,21 +64,21 @@ type WithGenerator func() (io.ReadCloser, error)
 type WithBytes []byte
 type WithString string
 
-type fileContentConfig struct {
+type contentConfig struct {
 	store    BytesStore
 	lazy     bool
 	generate func() (io.ReadCloser, error)
 }
 
-type defaultFileContent struct {
+type defaultContent struct {
 	mu       sync.Mutex
 	store    BytesStore
 	lazy     bool
 	generate func() (io.ReadCloser, error)
 }
 
-func NewFileContent(opts ...any) FileContent {
-	cfg := fileContentConfig{
+func NewContent(opts ...any) Content {
+	cfg := contentConfig{
 		store: &MemoryBytesStore{},
 		lazy:  true,
 	}
@@ -112,7 +112,7 @@ func NewFileContent(opts ...any) FileContent {
 		}
 	}
 
-	fc := &defaultFileContent{
+	fc := &defaultContent{
 		store:    cfg.store,
 		lazy:     cfg.lazy,
 		generate: cfg.generate,
@@ -125,7 +125,7 @@ func NewFileContent(opts ...any) FileContent {
 	return fc
 }
 
-func (fc *defaultFileContent) load() (*[]byte, error) {
+func (fc *defaultContent) load() (*[]byte, error) {
 	if fc.generate == nil {
 		return nil, nil // No generator provided, return nil or handle gracefully
 	}
@@ -144,7 +144,7 @@ func (fc *defaultFileContent) load() (*[]byte, error) {
 	return &b, nil
 }
 
-func (fc *defaultFileContent) Data() (*[]byte, error) {
+func (fc *defaultContent) Data() (*[]byte, error) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 
@@ -160,14 +160,14 @@ func (fc *defaultFileContent) Data() (*[]byte, error) {
 	return val, nil
 }
 
-func (fc *defaultFileContent) Close() error {
+func (fc *defaultContent) Close() error {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.store.Clear()
 	return nil
 }
 
-func (fc *defaultFileContent) String() string {
+func (fc *defaultContent) String() string {
 	b, err := fc.Data()
 	if err != nil {
 		return "" // Suppress error for templates
@@ -178,7 +178,7 @@ func (fc *defaultFileContent) String() string {
 	return string(*b)
 }
 
-func (fc *defaultFileContent) SetGenerator(generate func() (io.ReadCloser, error)) {
+func (fc *defaultContent) SetGenerator(generate func() (io.ReadCloser, error)) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.generate = generate

--- a/content_test.go
+++ b/content_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func testFileContentImpl(t *testing.T, fc FileContent, generateCallsPtr *int) {
+func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -51,49 +51,49 @@ func testFileContentImpl(t *testing.T, fc FileContent, generateCallsPtr *int) {
 	}
 }
 
-func TestFileContent_LazyWeak(t *testing.T) {
+func TestContent_LazyWeak(t *testing.T) {
 	generateCalls := 0
-	fc := NewFileContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
 		generateCalls++
 		return io.NopCloser(bytes.NewBufferString("hello world")), nil
 	}), UseWeakStorage(true), UseLazyLoading(true))
-	testFileContentImpl(t, fc, &generateCalls)
+	testContentImpl(t, fc, &generateCalls)
 }
 
-func TestFileContent_LazyMemory(t *testing.T) {
+func TestContent_LazyMemory(t *testing.T) {
 	generateCalls := 0
-	fc := NewFileContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
 		generateCalls++
 		return io.NopCloser(bytes.NewBufferString("hello world")), nil
 	}), UseMemoryStorage(true), UseLazyLoading(true))
-	testFileContentImpl(t, fc, &generateCalls)
+	testContentImpl(t, fc, &generateCalls)
 }
 
-func TestFileContent_EagerWeak(t *testing.T) {
+func TestContent_EagerWeak(t *testing.T) {
 	generateCalls := 0
-	fc := NewFileContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
 		generateCalls++
 		return io.NopCloser(bytes.NewBufferString("hello world")), nil
 	}), UseWeakStorage(true), UseEagerLoading(true))
-	testFileContentImpl(t, fc, &generateCalls)
+	testContentImpl(t, fc, &generateCalls)
 }
 
-func TestFileContent_EagerMemory(t *testing.T) {
+func TestContent_EagerMemory(t *testing.T) {
 	generateCalls := 0
-	fc := NewFileContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
 		generateCalls++
 		return io.NopCloser(bytes.NewBufferString("hello world")), nil
 	}), UseMemoryStorage(true), UseEagerLoading(true))
-	testFileContentImpl(t, fc, &generateCalls)
+	testContentImpl(t, fc, &generateCalls)
 }
 
-func TestFileContent_WithOptions(t *testing.T) {
-	fc := NewFileContent(WithBytes([]byte("hello bytes")))
+func TestContent_WithOptions(t *testing.T) {
+	fc := NewContent(WithBytes([]byte("hello bytes")))
 	if fc.String() != "hello bytes" {
 		t.Errorf("expected 'hello bytes', got '%s'", fc.String())
 	}
 
-	fc2 := NewFileContent(WithString("hello string"))
+	fc2 := NewContent(WithString("hello string"))
 	if fc2.String() != "hello string" {
 		t.Errorf("expected 'hello string', got '%s'", fc2.String())
 	}


### PR DESCRIPTION
Renamed `FileContent` to `Content` as requested.
- Renamed `file_content.go` -> `content.go`
- Renamed `file_content_test.go` -> `content_test.go`
- Updated `FileContent` interface and implementations to use `Content` and `content` respectively.

---
*PR created automatically by Jules for task [7556121045856541395](https://jules.google.com/task/7556121045856541395) started by @arran4*