### PR TITLE
ci: Fix manual release tag push in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,7 @@ jobs:
           TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
+          git tag "$TAG"
           git push origin "$TAG" || { sleep 2; git push origin "$TAG"; }
 
       - name: Create release with generated notes + discussion


### PR DESCRIPTION
Fixed a bug in the manual release GitHub Actions workflow where `git push origin "$TAG"` failed because the tag didn't exist locally. Added `git tag "$TAG"` right before pushing the tag to ensure successful workflow execution.

---
*PR created automatically by Jules for task [48669456675547821](https://jules.google.com/task/48669456675547821) started by @arran4*