### PR TITLE
Add cache validness check

### DIFF
--- a/content.go
+++ b/content.go
@@ -11,6 +11,8 @@ type Content interface {
 	Close() error
 	SetGenerator(func() (io.ReadCloser, error))
 	String() string
+	IsValid() bool
+	SetValidator(func() bool)
 }
 
 type BytesStore interface {
@@ -61,6 +63,7 @@ type UseLazyLoading bool
 type UseEagerLoading bool
 
 type WithGenerator func() (io.ReadCloser, error)
+type WithValidator func() bool
 type WithBytes []byte
 type WithString string
 
@@ -68,6 +71,7 @@ type contentConfig struct {
 	store    BytesStore
 	lazy     bool
 	generate func() (io.ReadCloser, error)
+	isValid  func() bool
 }
 
 type defaultContent struct {
@@ -75,6 +79,7 @@ type defaultContent struct {
 	store    BytesStore
 	lazy     bool
 	generate func() (io.ReadCloser, error)
+	isValid  func() bool
 }
 
 func NewContent(opts ...any) Content {
@@ -103,6 +108,8 @@ func NewContent(opts ...any) Content {
 			}
 		case WithGenerator:
 			cfg.generate = o
+		case WithValidator:
+			cfg.isValid = o
 		case WithBytes:
 			b := []byte(o)
 			cfg.store.Set(&b)
@@ -116,6 +123,7 @@ func NewContent(opts ...any) Content {
 		store:    cfg.store,
 		lazy:     cfg.lazy,
 		generate: cfg.generate,
+		isValid:  cfg.isValid,
 	}
 
 	if !fc.lazy {
@@ -147,6 +155,10 @@ func (fc *defaultContent) load() (*[]byte, error) {
 func (fc *defaultContent) Data() (*[]byte, error) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
+
+	if fc.isValid != nil && !fc.isValid() {
+		fc.store.Clear()
+	}
 
 	if val := fc.store.Get(); val != nil {
 		return val, nil
@@ -186,4 +198,20 @@ func (fc *defaultContent) SetGenerator(generate func() (io.ReadCloser, error)) {
 	if !fc.lazy {
 		_, _ = fc.load()
 	}
+}
+
+func (fc *defaultContent) IsValid() bool {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	if fc.isValid != nil && !fc.isValid() {
+		return false
+	}
+	return fc.store.Get() != nil
+}
+
+func (fc *defaultContent) SetValidator(isValid func() bool) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.isValid = isValid
 }

--- a/content_test.go
+++ b/content_test.go
@@ -98,3 +98,66 @@ func TestContent_WithOptions(t *testing.T) {
 		t.Errorf("expected 'hello string', got '%s'", fc2.String())
 	}
 }
+
+func TestContent_Validator(t *testing.T) {
+	generateCalls := 0
+	valid := true
+
+	fc := NewContent(
+		WithGenerator(func() (io.ReadCloser, error) {
+			generateCalls++
+			return io.NopCloser(bytes.NewBufferString("valid world")), nil
+		}),
+		WithValidator(func() bool {
+			return valid
+		}),
+	)
+
+	if fc.IsValid() {
+		t.Errorf("expected IsValid() to be false initially as cache is empty")
+	}
+
+	b, err := fc.Data()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if string(*b) != "valid world" {
+		t.Errorf("expected 'valid world', got '%s'", string(*b))
+	}
+	if generateCalls != 1 {
+		t.Errorf("expected 1 generate call, got %d", generateCalls)
+	}
+	if !fc.IsValid() {
+		t.Errorf("expected IsValid() to be true after cache is populated")
+	}
+
+	// Should not generate again
+	_, _ = fc.Data()
+	if generateCalls != 1 {
+		t.Errorf("expected still 1 generate call, got %d", generateCalls)
+	}
+
+	// Invalidate cache
+	valid = false
+	if fc.IsValid() {
+		t.Errorf("expected IsValid() to be false after validator changes")
+	}
+
+	// Fetching data should now generate again
+	b, err = fc.Data()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if string(*b) != "valid world" {
+		t.Errorf("expected 'valid world', got '%s'", string(*b))
+	}
+	if generateCalls != 2 {
+		t.Errorf("expected 2 generate calls, got %d", generateCalls)
+	}
+
+	// Test SetValidator
+	fc.SetValidator(func() bool { return false })
+	if fc.IsValid() {
+		t.Errorf("expected IsValid() to be false after SetValidator(false)")
+	}
+}


### PR DESCRIPTION
Introduced `WithValidator` option, `SetValidator` and `IsValid` methods to `Content` interface to allow checking and invalidating cached data. Adjusted `Data()` method to clear the underlying store and regenerate data if the cache becomes invalid. Also added tests to verify the cache validation and invalidation behavior.

---
*PR created automatically by Jules for task [14030354726168817728](https://jules.google.com/task/14030354726168817728) started by @arran4*