### PR TITLE
Refactor library to support Generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-weak-content
 
-A Go library providing an interface to lazily or eagerly cache generated content. It utilizes Go 1.24's new `weak` package to offer a memory-efficient `WeakBytesStore` alongside a standard `MemoryBytesStore`. This is great for managing ephemeral data, reducing garbage collection pressure, and maintaining efficient caching.
+A Go library providing an interface to lazily or eagerly cache generated content. It utilizes Go 1.24's new `weak` package to offer a memory-efficient `WeakStore[T]` alongside a standard `MemoryStore[T]`. This is great for managing ephemeral data, reducing garbage collection pressure, and maintaining efficient caching. With Generics support, you can cache any data type you need.
 
 ## Installation
 
@@ -12,6 +12,7 @@ go get github.com/arran4/go-weak-content
 
 ## Features
 
+- **Generics Support:** Cache any type `T` cleanly.
 - **Weak Pointers:** Leverage Go 1.24 `weak` pointers to automatically free cached memory when it is no longer referenced elsewhere.
 - **Thread-safe Loading:** Implemented safely for concurrent reads/writes using `sync.Mutex`.
 - **Flexible Options:** Highly configurable using functional options.
@@ -23,19 +24,18 @@ go get github.com/arran4/go-weak-content
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 
 	utils "github.com/arran4/go-weak-content"
 )
 
 func main() {
 	// Create a new Content instance that lazily loads, and stores via weak references.
-	fc := utils.NewContent(
-		utils.WithGenerator(func() (io.ReadCloser, error) {
+	fc := utils.NewContent[string](
+		utils.WithGenerator[string](func() (*string, error) {
 			// This will be called on the first Data() call
-			return io.NopCloser(bytes.NewBufferString("Hello from go-weak-content!")), nil
+			val := "Hello from go-weak-content!"
+			return &val, nil
 		}),
 		utils.UseWeakStorage(true),
 		utils.UseLazyLoading(true),
@@ -47,21 +47,20 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println(string(*data))
+	fmt.Println(*data)
 }
 ```
 
 ## Available Options
 
-The `NewContent(opts ...any)` constructor accepts the following options:
+The `NewContent[T any](opts ...any)` constructor accepts the following options:
 
 - **`UseWeakStorage(bool)`:** Uses a weak pointer (Go 1.24 `weak` package) for storage. The garbage collector may reclaim the cached data if it's not strongly referenced elsewhere.
-- **`UseMemoryStorage(bool)`:** Uses a strong reference for storage, keeping the bytes in memory until explicitly cleared (this is the default behavior).
+- **`UseMemoryStorage(bool)`:** Uses a strong reference for storage, keeping the data in memory until explicitly cleared (this is the default behavior).
 - **`UseLazyLoading(bool)`:** Delays the execution of the generator function until `Data()` or `String()` is first called (this is the default behavior).
 - **`UseEagerLoading(bool)`:** Immediately executes the generator function during the `NewContent` call.
-- **`WithGenerator(func() (io.ReadCloser, error))`:** The function that supplies the content when needed.
-- **`WithBytes([]byte)`:** Directly sets the content cache with the provided byte slice.
-- **`WithString(string)`:** Directly sets the content cache with the provided string.
+- **`WithGenerator[T](func() (*T, error))`:** The function that supplies the content when needed.
+- **`NewWithValue[T](val T)`:** Directly sets the content cache with the provided value (creates a `WithValue[T]`).
 
 ## License
 

--- a/content.go
+++ b/content.go
@@ -1,57 +1,57 @@
 package utils
 
 import (
-	"io"
+	"fmt"
 	"sync"
 	"weak"
 )
 
-type Content interface {
-	Data() (*[]byte, error)
+type Content[T any] interface {
+	Data() (*T, error)
 	Close() error
-	SetGenerator(func() (io.ReadCloser, error))
+	SetGenerator(func() (*T, error))
 	String() string
 }
 
-type BytesStore interface {
-	Get() *[]byte
-	Set(*[]byte)
+type Store[T any] interface {
+	Get() *T
+	Set(*T)
 	Clear()
 }
 
-type WeakBytesStore struct {
-	ptr weak.Pointer[[]byte]
+type WeakStore[T any] struct {
+	ptr weak.Pointer[T]
 }
 
-func (s *WeakBytesStore) Get() *[]byte {
+func (s *WeakStore[T]) Get() *T {
 	return s.ptr.Value()
 }
 
-func (s *WeakBytesStore) Set(val *[]byte) {
+func (s *WeakStore[T]) Set(val *T) {
 	if val == nil {
-		s.ptr = weak.Pointer[[]byte]{}
+		s.ptr = weak.Pointer[T]{}
 	} else {
 		s.ptr = weak.Make(val)
 	}
 }
 
-func (s *WeakBytesStore) Clear() {
-	s.ptr = weak.Pointer[[]byte]{}
+func (s *WeakStore[T]) Clear() {
+	s.ptr = weak.Pointer[T]{}
 }
 
-type MemoryBytesStore struct {
-	val *[]byte
+type MemoryStore[T any] struct {
+	val *T
 }
 
-func (s *MemoryBytesStore) Get() *[]byte {
+func (s *MemoryStore[T]) Get() *T {
 	return s.val
 }
 
-func (s *MemoryBytesStore) Set(val *[]byte) {
+func (s *MemoryStore[T]) Set(val *T) {
 	s.val = val
 }
 
-func (s *MemoryBytesStore) Clear() {
+func (s *MemoryStore[T]) Clear() {
 	s.val = nil
 }
 
@@ -60,26 +60,29 @@ type UseMemoryStorage bool
 type UseLazyLoading bool
 type UseEagerLoading bool
 
-type WithGenerator func() (io.ReadCloser, error)
-type WithBytes []byte
-type WithString string
+type WithGenerator[T any] func() (*T, error)
+type WithValue[T any] struct { val T }
 
-type contentConfig struct {
-	store    BytesStore
-	lazy     bool
-	generate func() (io.ReadCloser, error)
+func NewWithValue[T any](val T) WithValue[T] {
+	return WithValue[T]{val: val}
 }
 
-type defaultContent struct {
+type contentConfig[T any] struct {
+	store    Store[T]
+	lazy     bool
+	generate func() (*T, error)
+}
+
+type defaultContent[T any] struct {
 	mu       sync.Mutex
-	store    BytesStore
+	store    Store[T]
 	lazy     bool
-	generate func() (io.ReadCloser, error)
+	generate func() (*T, error)
 }
 
-func NewContent(opts ...any) Content {
-	cfg := contentConfig{
-		store: &MemoryBytesStore{},
+func NewContent[T any](opts ...any) Content[T] {
+	cfg := contentConfig[T]{
+		store: &MemoryStore[T]{},
 		lazy:  true,
 	}
 
@@ -87,11 +90,11 @@ func NewContent(opts ...any) Content {
 		switch o := opt.(type) {
 		case UseWeakStorage:
 			if o {
-				cfg.store = &WeakBytesStore{}
+				cfg.store = &WeakStore[T]{}
 			}
 		case UseMemoryStorage:
 			if o {
-				cfg.store = &MemoryBytesStore{}
+				cfg.store = &MemoryStore[T]{}
 			}
 		case UseLazyLoading:
 			if o {
@@ -101,18 +104,15 @@ func NewContent(opts ...any) Content {
 			if o {
 				cfg.lazy = false
 			}
-		case WithGenerator:
+		case WithGenerator[T]:
 			cfg.generate = o
-		case WithBytes:
-			b := []byte(o)
-			cfg.store.Set(&b)
-		case WithString:
-			b := []byte(o)
-			cfg.store.Set(&b)
+		case WithValue[T]:
+			val := o.val
+			cfg.store.Set(&val)
 		}
 	}
 
-	fc := &defaultContent{
+	fc := &defaultContent[T]{
 		store:    cfg.store,
 		lazy:     cfg.lazy,
 		generate: cfg.generate,
@@ -125,26 +125,20 @@ func NewContent(opts ...any) Content {
 	return fc
 }
 
-func (fc *defaultContent) load() (*[]byte, error) {
+func (fc *defaultContent[T]) load() (*T, error) {
 	if fc.generate == nil {
 		return nil, nil // No generator provided, return nil or handle gracefully
 	}
-	rc, err := fc.generate()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rc.Close() }()
-
-	b, err := io.ReadAll(rc)
+	val, err := fc.generate()
 	if err != nil {
 		return nil, err
 	}
 
-	fc.store.Set(&b)
-	return &b, nil
+	fc.store.Set(val)
+	return val, nil
 }
 
-func (fc *defaultContent) Data() (*[]byte, error) {
+func (fc *defaultContent[T]) Data() (*T, error) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 
@@ -160,25 +154,29 @@ func (fc *defaultContent) Data() (*[]byte, error) {
 	return val, nil
 }
 
-func (fc *defaultContent) Close() error {
+func (fc *defaultContent[T]) Close() error {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.store.Clear()
 	return nil
 }
 
-func (fc *defaultContent) String() string {
-	b, err := fc.Data()
-	if err != nil {
+func (fc *defaultContent[T]) String() string {
+	val, err := fc.Data()
+	if err != nil || val == nil {
 		return "" // Suppress error for templates
 	}
-	if b == nil {
-		return ""
+
+	if s, ok := any(*val).(string); ok {
+		return s
 	}
-	return string(*b)
+	if b, ok := any(*val).([]byte); ok {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", *val)
 }
 
-func (fc *defaultContent) SetGenerator(generate func() (io.ReadCloser, error)) {
+func (fc *defaultContent[T]) SetGenerator(generate func() (*T, error)) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.generate = generate

--- a/content_test.go
+++ b/content_test.go
@@ -1,13 +1,11 @@
 package utils
 
 import (
-	"bytes"
-	"io"
 	"sync"
 	"testing"
 )
 
-func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
+func testContentImpl(t *testing.T, fc Content[[]byte], generateCallsPtr *int) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -29,8 +27,9 @@ func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
 	}
 
 	// Test SetGenerator and Close
-	fc.SetGenerator(func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewBufferString("new world")), nil
+	fc.SetGenerator(func() (*[]byte, error) {
+		val := []byte("new world")
+		return &val, nil
 	})
 
 	b, err := fc.Data()
@@ -53,47 +52,51 @@ func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
 
 func TestContent_LazyWeak(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
+		val := []byte("hello world")
+		return &val, nil
 	}), UseWeakStorage(true), UseLazyLoading(true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_LazyMemory(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
+		val := []byte("hello world")
+		return &val, nil
 	}), UseMemoryStorage(true), UseLazyLoading(true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_EagerWeak(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
+		val := []byte("hello world")
+		return &val, nil
 	}), UseWeakStorage(true), UseEagerLoading(true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_EagerMemory(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
+		val := []byte("hello world")
+		return &val, nil
 	}), UseMemoryStorage(true), UseEagerLoading(true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_WithOptions(t *testing.T) {
-	fc := NewContent(WithBytes([]byte("hello bytes")))
+	fc := NewContent[[]byte](NewWithValue([]byte("hello bytes")))
 	if fc.String() != "hello bytes" {
 		t.Errorf("expected 'hello bytes', got '%s'", fc.String())
 	}
 
-	fc2 := NewContent(WithString("hello string"))
+	fc2 := NewContent[string](NewWithValue("hello string"))
 	if fc2.String() != "hello string" {
 		t.Errorf("expected 'hello string', got '%s'", fc2.String())
 	}


### PR DESCRIPTION
This refactoring updates the `go-weak-content` library to leverage Go Generics, allowing caching for any arbitrary type `T` rather than just byte slices.

Key changes:
- `Content`, `BytesStore` (`Store[T]`), `WeakBytesStore` (`WeakStore[T]`), and `MemoryBytesStore` (`MemoryStore[T]`) interfaces and structures have been genericized.
- The generator option now accepts generic values: `WithGenerator[T](func() (*T, error))`.
- Value initialization relies on generic value instantiation using `WithValue[T]` returned by `NewWithValue[T]`.
- Updated tests and README with new use cases.

---
*PR created automatically by Jules for task [155215056032136767](https://jules.google.com/task/155215056032136767) started by @arran4*