### PR TITLE
Add example.go

### DIFF
--- a/example.go
+++ b/example.go
@@ -1,0 +1,31 @@
+//go:build ignore
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	utils "github.com/arran4/go-weak-content"
+)
+
+func main() {
+	// Create a new Content instance that lazily loads, and stores via weak references.
+	fc := utils.NewContent(
+		utils.WithGenerator(func() (io.ReadCloser, error) {
+			// This will be called on the first Data() call
+			return io.NopCloser(bytes.NewBufferString("Hello from go-weak-content!")), nil
+		}),
+		utils.UseWeakStorage(true),
+		utils.UseLazyLoading(true),
+	)
+
+	// Generate and retrieve data
+	data, err := fc.Data()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(*data))
+}


### PR DESCRIPTION
Added `example.go` to the repository root to demonstrate how to use the `go-weak-content` library. Included the `//go:build ignore` directive so it doesn't cause conflicting package errors with the root module (`package utils` vs `package main`) when running `go build ./...`.

---
*PR created automatically by Jules for task [15471607181727770012](https://jules.google.com/task/15471607181727770012) started by @arran4*