### PR TITLE
Add Invalidate method and callbacks for invalidation, refetching, and closing

### DIFF
--- a/content.go
+++ b/content.go
@@ -13,6 +13,10 @@ type Content interface {
 	String() string
 	IsValid() bool
 	SetValidator(func() bool)
+	Invalidate()
+	SetOnInvalidated(func())
+	SetOnRefetched(func())
+	SetOnClosed(func())
 }
 
 type BytesStore interface {
@@ -67,19 +71,29 @@ type WithValidator func() bool
 type WithBytes []byte
 type WithString string
 
+type WithOnInvalidated func()
+type WithOnRefetched func()
+type WithOnClosed func()
+
 type contentConfig struct {
-	store    BytesStore
-	lazy     bool
-	generate func() (io.ReadCloser, error)
-	isValid  func() bool
+	store         BytesStore
+	lazy          bool
+	generate      func() (io.ReadCloser, error)
+	isValid       func() bool
+	onInvalidated func()
+	onRefetched   func()
+	onClosed      func()
 }
 
 type defaultContent struct {
-	mu       sync.Mutex
-	store    BytesStore
-	lazy     bool
-	generate func() (io.ReadCloser, error)
-	isValid  func() bool
+	mu            sync.Mutex
+	store         BytesStore
+	lazy          bool
+	generate      func() (io.ReadCloser, error)
+	isValid       func() bool
+	onInvalidated func()
+	onRefetched   func()
+	onClosed      func()
 }
 
 func NewContent(opts ...any) Content {
@@ -110,6 +124,12 @@ func NewContent(opts ...any) Content {
 			cfg.generate = o
 		case WithValidator:
 			cfg.isValid = o
+		case WithOnInvalidated:
+			cfg.onInvalidated = o
+		case WithOnRefetched:
+			cfg.onRefetched = o
+		case WithOnClosed:
+			cfg.onClosed = o
 		case WithBytes:
 			b := []byte(o)
 			cfg.store.Set(&b)
@@ -120,10 +140,13 @@ func NewContent(opts ...any) Content {
 	}
 
 	fc := &defaultContent{
-		store:    cfg.store,
-		lazy:     cfg.lazy,
-		generate: cfg.generate,
-		isValid:  cfg.isValid,
+		store:         cfg.store,
+		lazy:          cfg.lazy,
+		generate:      cfg.generate,
+		isValid:       cfg.isValid,
+		onInvalidated: cfg.onInvalidated,
+		onRefetched:   cfg.onRefetched,
+		onClosed:      cfg.onClosed,
 	}
 
 	if !fc.lazy {
@@ -149,6 +172,9 @@ func (fc *defaultContent) load() (*[]byte, error) {
 	}
 
 	fc.store.Set(&b)
+	if fc.onRefetched != nil {
+		fc.onRefetched()
+	}
 	return &b, nil
 }
 
@@ -157,7 +183,11 @@ func (fc *defaultContent) Data() (*[]byte, error) {
 	defer fc.mu.Unlock()
 
 	if fc.isValid != nil && !fc.isValid() {
+		wasCached := fc.store.Get() != nil
 		fc.store.Clear()
+		if wasCached && fc.onInvalidated != nil {
+			fc.onInvalidated()
+		}
 	}
 
 	if val := fc.store.Get(); val != nil {
@@ -176,6 +206,9 @@ func (fc *defaultContent) Close() error {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.store.Clear()
+	if fc.onClosed != nil {
+		fc.onClosed()
+	}
 	return nil
 }
 
@@ -194,7 +227,11 @@ func (fc *defaultContent) SetGenerator(generate func() (io.ReadCloser, error)) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.generate = generate
+	wasCached := fc.store.Get() != nil
 	fc.store.Clear()
+	if wasCached && fc.onInvalidated != nil {
+		fc.onInvalidated()
+	}
 	if !fc.lazy {
 		_, _ = fc.load()
 	}
@@ -214,4 +251,32 @@ func (fc *defaultContent) SetValidator(isValid func() bool) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.isValid = isValid
+}
+
+func (fc *defaultContent) Invalidate() {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	wasCached := fc.store.Get() != nil
+	fc.store.Clear()
+	if wasCached && fc.onInvalidated != nil {
+		fc.onInvalidated()
+	}
+}
+
+func (fc *defaultContent) SetOnInvalidated(onInvalidated func()) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.onInvalidated = onInvalidated
+}
+
+func (fc *defaultContent) SetOnRefetched(onRefetched func()) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.onRefetched = onRefetched
+}
+
+func (fc *defaultContent) SetOnClosed(onClosed func()) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.onClosed = onClosed
 }

--- a/content_test.go
+++ b/content_test.go
@@ -161,3 +161,93 @@ func TestContent_Validator(t *testing.T) {
 		t.Errorf("expected IsValid() to be false after SetValidator(false)")
 	}
 }
+
+func TestContent_Callbacks(t *testing.T) {
+	invalidationCount := 0
+	refetchCount := 0
+	closeCount := 0
+
+	fc := NewContent(
+		WithGenerator(func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewBufferString("callback data")), nil
+		}),
+		WithOnInvalidated(func() { invalidationCount++ }),
+		WithOnRefetched(func() { refetchCount++ }),
+		WithOnClosed(func() { closeCount++ }),
+	)
+
+	// Fetch data, should trigger refetch
+	_, err := fc.Data()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if refetchCount != 1 {
+		t.Errorf("expected 1 refetch, got %d", refetchCount)
+	}
+
+	// Fetch again, should not trigger refetch
+	_, _ = fc.Data()
+	if refetchCount != 1 {
+		t.Errorf("expected 1 refetch, got %d", refetchCount)
+	}
+
+	// Explicit invalidation
+	fc.Invalidate()
+	if invalidationCount != 1 {
+		t.Errorf("expected 1 invalidation, got %d", invalidationCount)
+	}
+
+	// Refetch data
+	_, _ = fc.Data()
+	if refetchCount != 2 {
+		t.Errorf("expected 2 refetches, got %d", refetchCount)
+	}
+
+	// Set new generator, should invalidate old data
+	fc.SetGenerator(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBufferString("new callback data")), nil
+	})
+	if invalidationCount != 2 {
+		t.Errorf("expected 2 invalidations, got %d", invalidationCount)
+	}
+
+	// Fetch new data
+	_, _ = fc.Data()
+	if refetchCount != 3 {
+		t.Errorf("expected 3 refetches, got %d", refetchCount)
+	}
+
+	// Validate closing
+	err = fc.Close()
+	if err != nil {
+		t.Errorf("expected no error from Close, got %v", err)
+	}
+	if closeCount != 1 {
+		t.Errorf("expected 1 close call, got %d", closeCount)
+	}
+
+	// Change callbacks via setters
+	newInvalidationCount := 0
+	newRefetchCount := 0
+	newCloseCount := 0
+
+	fc.SetOnInvalidated(func() { newInvalidationCount++ })
+	fc.SetOnRefetched(func() { newRefetchCount++ })
+	fc.SetOnClosed(func() { newCloseCount++ })
+
+	_, _ = fc.Data()
+	if newRefetchCount != 1 {
+		t.Errorf("expected new refetch count 1, got %d", newRefetchCount)
+	}
+
+	fc.Invalidate()
+	if newInvalidationCount != 1 {
+		t.Errorf("expected new invalidation count 1, got %d", newInvalidationCount)
+	}
+
+	_ = fc.Close()
+	if newCloseCount != 1 {
+		t.Errorf("expected new close count 1, got %d", newCloseCount)
+	}
+}


### PR DESCRIPTION
This adds an invalidator and callback functions as requested. It implements `Invalidate()` to allow explicit invalidation, and provides options and setter methods to configure callbacks for when content is invalidated (`OnInvalidated`), refetched (`OnRefetched`), and closed (`OnClosed`). Exhaustive unit tests are also included.

---
*PR created automatically by Jules for task [10267462857982306325](https://jules.google.com/task/10267462857982306325) started by @arran4*