### PR TITLE
Refactor library to support generic caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-weak-content
 
-A Go library providing an interface to lazily or eagerly cache generated content. It utilizes Go 1.24's new `weak` package to offer a memory-efficient `WeakBytesStore` alongside a standard `MemoryBytesStore`. This is great for managing ephemeral data, reducing garbage collection pressure, and maintaining efficient caching.
+A Go library providing an interface to lazily or eagerly cache generated content. It utilizes Go 1.24's new `weak` package to offer a memory-efficient `WeakStore` alongside a standard `MemoryStore`. This is great for managing ephemeral data, reducing garbage collection pressure, and maintaining efficient caching.
 
 ## Installation
 
@@ -12,6 +12,7 @@ go get github.com/arran4/go-weak-content
 
 ## Features
 
+- **Generics Support:** Caches any type (`Content[T any]`) effectively.
 - **Weak Pointers:** Leverage Go 1.24 `weak` pointers to automatically free cached memory when it is no longer referenced elsewhere.
 - **Thread-safe Loading:** Implemented safely for concurrent reads/writes using `sync.Mutex`.
 - **Flexible Options:** Highly configurable using functional options.
@@ -27,22 +28,21 @@ This is ideal for large datasets where you want the garbage collector to free me
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 
 	utils "github.com/arran4/go-weak-content"
 )
 
 func main() {
 	// Create a new Content instance that lazily loads, and stores via weak references.
-	fc := utils.NewContent(
-		utils.WithGenerator(func() (io.ReadCloser, error) {
+	fc := utils.NewContent[[]byte](
+		utils.WithGenerator[[]byte](func() (*[]byte, error) {
 			// This will be called on the first Data() call
-			return io.NopCloser(bytes.NewBufferString("Hello from go-weak-content!")), nil
+			b := []byte("Hello from go-weak-content!")
+			return &b, nil
 		}),
-		utils.UseWeakStorage(true),
-		utils.UseLazyLoading(true),
+		utils.UseWeakStorage[[]byte](true),
+		utils.UseLazyLoading[[]byte](true),
 	)
 
 	// Generate and retrieve data
@@ -63,21 +63,20 @@ If you need the data to be generated immediately and kept firmly in memory, you 
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 
 	utils "github.com/arran4/go-weak-content"
 )
 
 func main() {
-	fc := utils.NewContent(
-		utils.WithGenerator(func() (io.ReadCloser, error) {
+	fc := utils.NewContent[string](
+		utils.WithGenerator[string](func() (*string, error) {
 			// Executed immediately
-			return io.NopCloser(bytes.NewBufferString("Eagerly loaded data!")), nil
+			str := "Eagerly loaded data!"
+			return &str, nil
 		}),
-		utils.UseMemoryStorage(true),
-		utils.UseEagerLoading(true),
+		utils.UseMemoryStorage[string](true),
+		utils.UseEagerLoading[string](true),
 	)
 
 	fmt.Println(fc.String()) // "Eagerly loaded data!"
@@ -98,36 +97,35 @@ import (
 )
 
 func main() {
-	fc := utils.NewContent(utils.WithString("Pre-existing content"))
+	fc := utils.NewContent[string](utils.WithValue[string]("Pre-existing content"))
 	fmt.Println(fc.String()) // "Pre-existing content"
 }
 ```
 
 ## Interfaces
 
-### `Content`
+### `Content[T any]`
 The `Content` interface represents the core of the library, providing methods to interact with cached content:
-- **`Data() (*[]byte, error)`**: Returns a pointer to the byte slice containing the generated content. If the content hasn't been generated yet (lazy loading), it will generate it.
+- **`Data() (*T, error)`**: Returns a pointer to the value containing the generated content. If the content hasn't been generated yet (lazy loading), it will generate it.
 - **`Close() error`**: Clears the currently cached data from the underlying store.
-- **`SetGenerator(func() (io.ReadCloser, error))`**: Updates the generator function and clears any currently cached data. If eager loading is enabled, it will immediately generate the content.
-- **`String() string`**: A convenience method that returns the generated content as a string. Suppresses errors and returns an empty string if data generation fails.
+- **`SetGenerator(func() (*T, error))`**: Updates the generator function and clears any currently cached data. If eager loading is enabled, it will immediately generate the content.
+- **`String() string`**: A convenience method that returns the generated content as a string. Suppresses errors and returns an empty string if data generation fails. If the type is `string`, `[]byte`, or `fmt.Stringer`, it will natively format it.
 
 ### Storage Interfaces
-- **`BytesStore`**: The interface defining how bytes are stored and retrieved (`Get()`, `Set()`, `Clear()`).
-- **`WeakBytesStore`**: An implementation of `BytesStore` utilizing Go 1.24 `weak` pointers.
-- **`MemoryBytesStore`**: A standard implementation of `BytesStore` keeping a strong reference in memory.
+- **`Store[T any]`**: The interface defining how objects are stored and retrieved (`Get()`, `Set()`, `Clear()`).
+- **`WeakStore[T any]`**: An implementation of `Store[T any]` utilizing Go 1.24 `weak` pointers.
+- **`MemoryStore[T any]`**: A standard implementation of `Store[T any]` keeping a strong reference in memory.
 
 ## Available Options
 
-The `NewContent(opts ...any)` constructor accepts the following options:
+The `NewContent[T any](opts ...Option[T])` constructor accepts the following options:
 
-- **`UseWeakStorage(bool)`:** Uses a weak pointer (Go 1.24 `weak` package) for storage. The garbage collector may reclaim the cached data if it's not strongly referenced elsewhere.
-- **`UseMemoryStorage(bool)`:** Uses a strong reference for storage, keeping the bytes in memory until explicitly cleared (this is the default behavior).
-- **`UseLazyLoading(bool)`:** Delays the execution of the generator function until `Data()` or `String()` is first called (this is the default behavior).
-- **`UseEagerLoading(bool)`:** Immediately executes the generator function during the `NewContent` call.
-- **`WithGenerator(func() (io.ReadCloser, error))`:** The function that supplies the content when needed.
-- **`WithBytes([]byte)`:** Directly sets the content cache with the provided byte slice.
-- **`WithString(string)`:** Directly sets the content cache with the provided string.
+- **`UseWeakStorage[T](bool)`:** Uses a weak pointer (Go 1.24 `weak` package) for storage. The garbage collector may reclaim the cached data if it's not strongly referenced elsewhere.
+- **`UseMemoryStorage[T](bool)`:** Uses a strong reference for storage, keeping the object in memory until explicitly cleared (this is the default behavior).
+- **`UseLazyLoading[T](bool)`:** Delays the execution of the generator function until `Data()` or `String()` is first called (this is the default behavior).
+- **`UseEagerLoading[T](bool)`:** Immediately executes the generator function during the `NewContent` call.
+- **`WithGenerator[T](func() (*T, error))`:** The function that supplies the content when needed.
+- **`WithValue[T](T)`:** Directly sets the content cache with the provided static value.
 
 ## License
 

--- a/content.go
+++ b/content.go
@@ -1,125 +1,140 @@
 package utils
 
 import (
-	"io"
+	"fmt"
 	"sync"
 	"weak"
 )
 
-type Content interface {
-	Data() (*[]byte, error)
+type Content[T any] interface {
+	Data() (*T, error)
 	Close() error
-	SetGenerator(func() (io.ReadCloser, error))
+	SetGenerator(func() (*T, error))
 	String() string
 	IsValid() bool
 	SetValidator(func() bool)
 }
 
-type BytesStore interface {
-	Get() *[]byte
-	Set(*[]byte)
+type Store[T any] interface {
+	Get() *T
+	Set(*T)
 	Clear()
 }
 
-type WeakBytesStore struct {
-	ptr weak.Pointer[[]byte]
+type WeakStore[T any] struct {
+	ptr weak.Pointer[T]
 }
 
-func (s *WeakBytesStore) Get() *[]byte {
+func (s *WeakStore[T]) Get() *T {
 	return s.ptr.Value()
 }
 
-func (s *WeakBytesStore) Set(val *[]byte) {
+func (s *WeakStore[T]) Set(val *T) {
 	if val == nil {
-		s.ptr = weak.Pointer[[]byte]{}
+		s.ptr = weak.Pointer[T]{}
 	} else {
 		s.ptr = weak.Make(val)
 	}
 }
 
-func (s *WeakBytesStore) Clear() {
-	s.ptr = weak.Pointer[[]byte]{}
+func (s *WeakStore[T]) Clear() {
+	s.ptr = weak.Pointer[T]{}
 }
 
-type MemoryBytesStore struct {
-	val *[]byte
+type MemoryStore[T any] struct {
+	val *T
 }
 
-func (s *MemoryBytesStore) Get() *[]byte {
+func (s *MemoryStore[T]) Get() *T {
 	return s.val
 }
 
-func (s *MemoryBytesStore) Set(val *[]byte) {
+func (s *MemoryStore[T]) Set(val *T) {
 	s.val = val
 }
 
-func (s *MemoryBytesStore) Clear() {
+func (s *MemoryStore[T]) Clear() {
 	s.val = nil
 }
 
-type UseWeakStorage bool
-type UseMemoryStorage bool
-type UseLazyLoading bool
-type UseEagerLoading bool
+type Option[T any] func(*contentConfig[T])
 
-type WithGenerator func() (io.ReadCloser, error)
-type WithValidator func() bool
-type WithBytes []byte
-type WithString string
+func UseWeakStorage[T any](use bool) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		if use {
+			cfg.store = &WeakStore[T]{}
+		}
+	}
+}
 
-type contentConfig struct {
-	store    BytesStore
+func UseMemoryStorage[T any](use bool) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		if use {
+			cfg.store = &MemoryStore[T]{}
+		}
+	}
+}
+
+func UseLazyLoading[T any](use bool) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		if use {
+			cfg.lazy = true
+		}
+	}
+}
+
+func UseEagerLoading[T any](use bool) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		if use {
+			cfg.lazy = false
+		}
+	}
+}
+
+func WithGenerator[T any](generate func() (*T, error)) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		cfg.generate = generate
+	}
+}
+
+func WithValidator[T any](isValid func() bool) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		cfg.isValid = isValid
+	}
+}
+
+func WithValue[T any](val T) Option[T] {
+	return func(cfg *contentConfig[T]) {
+		cfg.store.Set(&val)
+	}
+}
+
+type contentConfig[T any] struct {
+	store    Store[T]
 	lazy     bool
-	generate func() (io.ReadCloser, error)
+	generate func() (*T, error)
 	isValid  func() bool
 }
 
-type defaultContent struct {
+type defaultContent[T any] struct {
 	mu       sync.Mutex
-	store    BytesStore
+	store    Store[T]
 	lazy     bool
-	generate func() (io.ReadCloser, error)
+	generate func() (*T, error)
 	isValid  func() bool
 }
 
-func NewContent(opts ...any) Content {
-	cfg := contentConfig{
-		store: &MemoryBytesStore{},
+func NewContent[T any](opts ...Option[T]) Content[T] {
+	cfg := contentConfig[T]{
+		store: &MemoryStore[T]{},
 		lazy:  true,
 	}
 
 	for _, opt := range opts {
-		switch o := opt.(type) {
-		case UseWeakStorage:
-			if o {
-				cfg.store = &WeakBytesStore{}
-			}
-		case UseMemoryStorage:
-			if o {
-				cfg.store = &MemoryBytesStore{}
-			}
-		case UseLazyLoading:
-			if o {
-				cfg.lazy = true
-			}
-		case UseEagerLoading:
-			if o {
-				cfg.lazy = false
-			}
-		case WithGenerator:
-			cfg.generate = o
-		case WithValidator:
-			cfg.isValid = o
-		case WithBytes:
-			b := []byte(o)
-			cfg.store.Set(&b)
-		case WithString:
-			b := []byte(o)
-			cfg.store.Set(&b)
-		}
+		opt(&cfg)
 	}
 
-	fc := &defaultContent{
+	fc := &defaultContent[T]{
 		store:    cfg.store,
 		lazy:     cfg.lazy,
 		generate: cfg.generate,
@@ -133,26 +148,22 @@ func NewContent(opts ...any) Content {
 	return fc
 }
 
-func (fc *defaultContent) load() (*[]byte, error) {
+func (fc *defaultContent[T]) load() (*T, error) {
 	if fc.generate == nil {
 		return nil, nil // No generator provided, return nil or handle gracefully
 	}
-	rc, err := fc.generate()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rc.Close() }()
-
-	b, err := io.ReadAll(rc)
+	val, err := fc.generate()
 	if err != nil {
 		return nil, err
 	}
 
-	fc.store.Set(&b)
-	return &b, nil
+	if val != nil {
+		fc.store.Set(val)
+	}
+	return val, nil
 }
 
-func (fc *defaultContent) Data() (*[]byte, error) {
+func (fc *defaultContent[T]) Data() (*T, error) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 
@@ -172,25 +183,36 @@ func (fc *defaultContent) Data() (*[]byte, error) {
 	return val, nil
 }
 
-func (fc *defaultContent) Close() error {
+func (fc *defaultContent[T]) Close() error {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.store.Clear()
 	return nil
 }
 
-func (fc *defaultContent) String() string {
-	b, err := fc.Data()
+func (fc *defaultContent[T]) String() string {
+	val, err := fc.Data()
 	if err != nil {
 		return "" // Suppress error for templates
 	}
-	if b == nil {
+	if val == nil {
 		return ""
 	}
-	return string(*b)
+
+	// We use any(*val) to be able to switch its type safely
+	switch v := any(*val).(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
-func (fc *defaultContent) SetGenerator(generate func() (io.ReadCloser, error)) {
+func (fc *defaultContent[T]) SetGenerator(generate func() (*T, error)) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.generate = generate
@@ -200,7 +222,7 @@ func (fc *defaultContent) SetGenerator(generate func() (io.ReadCloser, error)) {
 	}
 }
 
-func (fc *defaultContent) IsValid() bool {
+func (fc *defaultContent[T]) IsValid() bool {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 
@@ -210,7 +232,7 @@ func (fc *defaultContent) IsValid() bool {
 	return fc.store.Get() != nil
 }
 
-func (fc *defaultContent) SetValidator(isValid func() bool) {
+func (fc *defaultContent[T]) SetValidator(isValid func() bool) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	fc.isValid = isValid

--- a/content_test.go
+++ b/content_test.go
@@ -1,13 +1,11 @@
 package utils
 
 import (
-	"bytes"
-	"io"
 	"sync"
 	"testing"
 )
 
-func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
+func testContentImpl(t *testing.T, fc Content[[]byte], generateCallsPtr *int) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -29,8 +27,9 @@ func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
 	}
 
 	// Test SetGenerator and Close
-	fc.SetGenerator(func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewBufferString("new world")), nil
+	fc.SetGenerator(func() (*[]byte, error) {
+		b := []byte("new world")
+		return &b, nil
 	})
 
 	b, err := fc.Data()
@@ -53,47 +52,51 @@ func testContentImpl(t *testing.T, fc Content, generateCallsPtr *int) {
 
 func TestContent_LazyWeak(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
-	}), UseWeakStorage(true), UseLazyLoading(true))
+		b := []byte("hello world")
+		return &b, nil
+	}), UseWeakStorage[[]byte](true), UseLazyLoading[[]byte](true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_LazyMemory(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
-	}), UseMemoryStorage(true), UseLazyLoading(true))
+		b := []byte("hello world")
+		return &b, nil
+	}), UseMemoryStorage[[]byte](true), UseLazyLoading[[]byte](true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_EagerWeak(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
-	}), UseWeakStorage(true), UseEagerLoading(true))
+		b := []byte("hello world")
+		return &b, nil
+	}), UseWeakStorage[[]byte](true), UseEagerLoading[[]byte](true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_EagerMemory(t *testing.T) {
 	generateCalls := 0
-	fc := NewContent(WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](WithGenerator[[]byte](func() (*[]byte, error) {
 		generateCalls++
-		return io.NopCloser(bytes.NewBufferString("hello world")), nil
-	}), UseMemoryStorage(true), UseEagerLoading(true))
+		b := []byte("hello world")
+		return &b, nil
+	}), UseMemoryStorage[[]byte](true), UseEagerLoading[[]byte](true))
 	testContentImpl(t, fc, &generateCalls)
 }
 
 func TestContent_WithOptions(t *testing.T) {
-	fc := NewContent(WithBytes([]byte("hello bytes")))
+	fc := NewContent[[]byte](WithValue[[]byte]([]byte("hello bytes")))
 	if fc.String() != "hello bytes" {
 		t.Errorf("expected 'hello bytes', got '%s'", fc.String())
 	}
 
-	fc2 := NewContent(WithString("hello string"))
+	fc2 := NewContent[string](WithValue[string]("hello string"))
 	if fc2.String() != "hello string" {
 		t.Errorf("expected 'hello string', got '%s'", fc2.String())
 	}
@@ -103,12 +106,13 @@ func TestContent_Validator(t *testing.T) {
 	generateCalls := 0
 	valid := true
 
-	fc := NewContent(
-		WithGenerator(func() (io.ReadCloser, error) {
+	fc := NewContent[[]byte](
+		WithGenerator[[]byte](func() (*[]byte, error) {
 			generateCalls++
-			return io.NopCloser(bytes.NewBufferString("valid world")), nil
+			b := []byte("valid world")
+			return &b, nil
 		}),
-		WithValidator(func() bool {
+		WithValidator[[]byte](func() bool {
 			return valid
 		}),
 	)


### PR DESCRIPTION
Refactored the library to use Go Generics, allowing caching of arbitrary types (`Content[T any]`) rather than strictly returning and evaluating `[]byte`. This includes refactoring the underlying caching implementations and functional options to strictly type the generator API and internal storages.

---
*PR created automatically by Jules for task [12996385471330857132](https://jules.google.com/task/12996385471330857132) started by @arran4*