### PR TITLE
docs: add diagnostics for CI workflow absence

### DIFF
--- a/docs/ci/DIAGNOSTICS.md
+++ b/docs/ci/DIAGNOSTICS.md
@@ -1,36 +1,33 @@
 # CI/CD Workflow Diagnostics
 
 ## Issue Summary
-GitHub Actions workflows (`ci.yml`) are not triggering for `push` or `pull_request` events since PR #15 was merged.
+Historically, GitHub Actions workflows (`ci.yml`) stopped triggering for `push` or `pull_request` events, notably resulting in no runs for PR #15 or its merge.
 
-## Root Cause
-The root cause is a GitHub repository/account Actions policy setting blocking workflow execution. The `.github/workflows/ci.yml` file is syntactically correct and fully validates against `actionlint`. Because entirely missing workflow runs indicate rejection at the GitHub registration/admission layer (rather than a runtime failure), the issue lies in the Actions configuration.
+## Current State & Evidence
+The `ci.yml` workflow is currently **active** and **successfully executing**.
+Opening PR #24 generated a successful `pull_request` run (**#105**, ID `34014644270`). This run completed all steps (Route event, capability discovery, golangci-lint, dependency review, `go vet`, `go test`, and Release Validation Gate) without requiring any changes to the workflow YAML file.
 
-## Required Repository Settings Correction
-Please check and correct the following settings in the repository (or organization policy):
+This establishes that:
+1. **Workflow Syntax is Valid:** The schema is fully compliant with GitHub Actions standards (`actionlint` returns 0 errors).
+2. **Execution is Permitted:** There are no repository or account-level policy blockers currently preventing `pull_request` events from triggering this workflow.
 
-1. **Actions Enablement:**
-   Navigate to **Settings → Actions → General**.
-   Ensure that **Actions permissions** are set to **"Allow all actions and reusable workflows"** or **"Allow [org] and select non-[org], actions and reusable workflows"**. If it is set to "Disable actions", no workflows will run.
+## Historical Absence of Runs
+The chronological evidence is:
+* **2026-04-08:** The last `push` and `pull_request` runs before this incident occurred.
+* **2026-06-08:** The last `schedule` run occurred.
+* **2026-09-05:** PR #15 was created and merged, but no workflow run was triggered.
+* **2026-09-06:** PR #24 was created and successfully triggered run #105.
 
-2. **Workflow Execution Policies:**
-   Navigate to **Settings → Actions → Policies**.
-   Ensure there are no event-routing restrictions preventing `push` or `pull_request` events from triggering workflows, or restricting the specific actor.
+Since more than 60 days of repository inactivity elapsed between June and September, it is highly probable that the workflow was automatically disabled by GitHub (`disabled_inactivity` state) prior to PR #15. While we cannot definitively prove the exact moment of reactivation (whether manual or automated), the workflow is now fully active.
 
-## Diagnostic Evidence
+## Inconclusive Diagnostic Tests
+Attempting to trigger the workflow manually using `workflow_dispatch` via the API resulted in a `401 Bad credentials` error. This was an authentication failure due to the diagnostic environment lacking a valid `GITHUB_TOKEN`, and is not evidence of a workflow admission policy or registration issue.
 
-### `actionlint` Validation
-Running `actionlint` locally on `.github/workflows/ci.yml` returns `0` errors. The schema is fully compliant with GitHub Actions standards.
-
-### `workflow_dispatch` Diagnostic
-Attempting to trigger the workflow manually using GitHub CLI fails at the API level (e.g. `Bad credentials` or immediate rejection), which confirms the API/GitHub layer is refusing workflow dispatch entirely.
-
-### Local Test Results
+## Local Test Results
+- `actionlint .github/workflows/ci.yml` passed with 0 errors.
 - `go test ./...` passed successfully.
 - `go vet ./...` passed successfully.
 
-## Manual Verification Required
-Once the repository settings have been updated to allow Actions execution, please manually verify by:
-1. Pushing a new commit to the repository.
-2. Opening a pull request.
-3. Confirming that a new workflow run appears in the **Actions** tab.
+## Verification Required
+* PR-triggered CI is now demonstrably working (Run #105).
+* Verification of `push` event routing to the `main` branch is still required after this diagnostic PR is merged or closed, to completely resolve the acceptance criteria of the original issue.

--- a/docs/ci/DIAGNOSTICS.md
+++ b/docs/ci/DIAGNOSTICS.md
@@ -1,0 +1,36 @@
+# CI/CD Workflow Diagnostics
+
+## Issue Summary
+GitHub Actions workflows (`ci.yml`) are not triggering for `push` or `pull_request` events since PR #15 was merged.
+
+## Root Cause
+The root cause is a GitHub repository/account Actions policy setting blocking workflow execution. The `.github/workflows/ci.yml` file is syntactically correct and fully validates against `actionlint`. Because entirely missing workflow runs indicate rejection at the GitHub registration/admission layer (rather than a runtime failure), the issue lies in the Actions configuration.
+
+## Required Repository Settings Correction
+Please check and correct the following settings in the repository (or organization policy):
+
+1. **Actions Enablement:**
+   Navigate to **Settings → Actions → General**.
+   Ensure that **Actions permissions** are set to **"Allow all actions and reusable workflows"** or **"Allow [org] and select non-[org], actions and reusable workflows"**. If it is set to "Disable actions", no workflows will run.
+
+2. **Workflow Execution Policies:**
+   Navigate to **Settings → Actions → Policies**.
+   Ensure there are no event-routing restrictions preventing `push` or `pull_request` events from triggering workflows, or restricting the specific actor.
+
+## Diagnostic Evidence
+
+### `actionlint` Validation
+Running `actionlint` locally on `.github/workflows/ci.yml` returns `0` errors. The schema is fully compliant with GitHub Actions standards.
+
+### `workflow_dispatch` Diagnostic
+Attempting to trigger the workflow manually using GitHub CLI fails at the API level (e.g. `Bad credentials` or immediate rejection), which confirms the API/GitHub layer is refusing workflow dispatch entirely.
+
+### Local Test Results
+- `go test ./...` passed successfully.
+- `go vet ./...` passed successfully.
+
+## Manual Verification Required
+Once the repository settings have been updated to allow Actions execution, please manually verify by:
+1. Pushing a new commit to the repository.
+2. Opening a pull request.
+3. Confirming that a new workflow run appears in the **Actions** tab.


### PR DESCRIPTION
This PR documents the investigation into issue #23 without changing `.github/workflows/ci.yml` or weakening the release-safe architecture introduced by PR #15.

### Root cause / current conclusion
The workflow file itself is valid and is currently active. The historical root cause cannot be proven conclusively from the available audit trail.

The strongest explanation is GitHub's inactivity handling for public repositories: this repository had more than 60 days without repository activity after the last scheduled run, and mixed workflows containing `schedule` can enter an inactivity-disabled state that also prevents their other triggers from creating runs. The exact moment and mechanism by which this workflow returned to `active` state was not captured, so this remains a well-supported historical explanation rather than a proven state transition.

A repository/account Actions policy blocker is **not** the current cause. PR #24 has now demonstrated successful `pull_request` execution twice with the unchanged workflow.

### What changed
Added `docs/ci/DIAGNOSTICS.md` as an evidence-based incident/diagnostic record covering:
- workflow validation;
- historical run chronology;
- current successful PR triggering;
- the plausible inactivity-disable explanation and its limits;
- the inconclusive `workflow_dispatch` test;
- remaining `push`-to-`main` verification.

No workflow YAML, permissions, release ownership, tag-routing, or publication behavior was changed.

### What was verified
- `actionlint .github/workflows/ci.yml` passes with 0 errors.
- `go test ./...` passes.
- `go vet ./...` passes.
- PR #24 opening triggered CI/CD run #105 (`34014644270`) successfully.
- Corrective commit `aac93f25150016dfac9ec5b8aa9b3c501b65addc` triggered a second `pull_request`/synchronize CI/CD run #106 (`34015201636`) successfully.
- The prior `401 Bad credentials` result from the attempted `workflow_dispatch` was an authentication failure in the diagnostic environment and is not evidence of Actions admission/policy rejection.

### Manual/post-merge verification still required
The remaining acceptance criterion from issue #23 is to confirm that a subsequent `push`/merge commit to `main` creates the expected CI/CD run. This PR must not be merged as part of this task; perform that verification only after an explicit merge instruction.

Refs #23

---
*PR created automatically by Jules for task [9032166285063247091](https://jules.google.com/task/9032166285063247091) started by @arran4*