### PR TITLE
Fix functional option ordering destructive behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,15 @@ The `Content` interface represents the core of the library, providing methods to
 
 The `NewContent[T any](opts ...Option[T])` constructor accepts the following options:
 
+> **Note on Option Ordering:** Storage options (`UseWeakStorage` and `UseMemoryStorage`) preserve existing content. If multiple storage options are provided, the last one provided wins. `WithValue` will have its value retained regardless of whether it appears before or after storage configuration options.
+
 - **`UseWeakStorage[T](bool)`:** Uses a weak pointer (Go 1.24 `weak` package) for storage. The garbage collector may reclaim the cached data if it's not strongly referenced elsewhere.
 - **`UseMemoryStorage[T](bool)`:** Uses a strong reference for storage, keeping the object in memory until explicitly cleared (this is the default behavior).
 - **`UseLazyLoading[T](bool)`:** Delays the execution of the generator function until `Data()` or `String()` is first called (this is the default behavior).
 - **`UseEagerLoading[T](bool)`:** Immediately executes the generator function during the `NewContent` call.
 - **`WithGenerator[T](func() (*T, error))`:** The function that supplies the content when needed.
 - **`WithValidator[T](func() bool)`:** Sets a function that determines whether the currently cached content is still valid.
-- **`WithValue[T](T)`:** Directly sets the content cache with the provided static value.
+- **`WithValue[T](T)`:** Directly sets the content cache with the provided static value. Note that when used in combination with `UseWeakStorage`, the initial value only retains a weak reference internally and will legitimately become eligible for garbage collection unless a strong reference is maintained elsewhere.
 - **`WithOnGenerate[T](func(val *T, err error))`:** A callback executed immediately after a generation attempt.
 - **`WithOnInvalidate[T](func())`:** A callback executed when content is cleared from the store due to invalidation.
 - **`WithOnClose[T](func())`:** A callback executed when `Close()` is called.

--- a/content.go
+++ b/content.go
@@ -86,15 +86,25 @@ func (s *MemoryStore[T]) Clear() {
 	s.val = nil
 }
 
+type configStore[T any] struct {
+	val    *T
+	isWeak bool
+}
+
+func (s *configStore[T]) Get() *T    { return s.val }
+func (s *configStore[T]) Set(val *T) { s.val = val }
+func (s *configStore[T]) Clear()     { s.val = nil }
+
 type Option[T any] func(*contentImpl[T])
 
 func UseWeakStorage[T any](use bool) Option[T] {
 	return func(fc *contentImpl[T]) {
 		if use {
-			val := fc.store.Get()
-			fc.store = &WeakStore[T]{}
-			if val != nil {
-				fc.store.Set(val)
+			if cs, ok := fc.store.(*configStore[T]); ok {
+				cs.isWeak = true
+			} else {
+				val := fc.store.Get()
+				fc.store = &configStore[T]{val: val, isWeak: true}
 			}
 		}
 	}
@@ -103,10 +113,11 @@ func UseWeakStorage[T any](use bool) Option[T] {
 func UseMemoryStorage[T any](use bool) Option[T] {
 	return func(fc *contentImpl[T]) {
 		if use {
-			val := fc.store.Get()
-			fc.store = &MemoryStore[T]{}
-			if val != nil {
-				fc.store.Set(val)
+			if cs, ok := fc.store.(*configStore[T]); ok {
+				cs.isWeak = false
+			} else {
+				val := fc.store.Get()
+				fc.store = &configStore[T]{val: val, isWeak: false}
 			}
 		}
 	}
@@ -311,12 +322,24 @@ func wrapValidator[T any](origIsVal func() bool) func() bool {
 
 func NewContent[T any](opts ...Option[T]) Content[T] {
 	fc := &contentImpl[T]{
-		store: &MemoryStore[T]{},
+		store: &configStore[T]{isWeak: false},
 		lazy:  true,
 	}
 
 	for _, opt := range opts {
 		opt(fc)
+	}
+
+	if cs, ok := fc.store.(*configStore[T]); ok {
+		val := cs.Get()
+		if cs.isWeak {
+			fc.store = &WeakStore[T]{}
+		} else {
+			fc.store = &MemoryStore[T]{}
+		}
+		if val != nil {
+			fc.store.Set(val)
+		}
 	}
 
 	vStore := &versionedStore[T]{

--- a/content.go
+++ b/content.go
@@ -91,7 +91,11 @@ type Option[T any] func(*contentImpl[T])
 func UseWeakStorage[T any](use bool) Option[T] {
 	return func(fc *contentImpl[T]) {
 		if use {
+			val := fc.store.Get()
 			fc.store = &WeakStore[T]{}
+			if val != nil {
+				fc.store.Set(val)
+			}
 		}
 	}
 }
@@ -99,7 +103,11 @@ func UseWeakStorage[T any](use bool) Option[T] {
 func UseMemoryStorage[T any](use bool) Option[T] {
 	return func(fc *contentImpl[T]) {
 		if use {
+			val := fc.store.Get()
 			fc.store = &MemoryStore[T]{}
+			if val != nil {
+				fc.store.Set(val)
+			}
 		}
 	}
 }

--- a/content_test.go
+++ b/content_test.go
@@ -169,6 +169,22 @@ func TestContent_StorageOptionOrdering_Weak(t *testing.T) {
 	if fc.String() != "" {
 		t.Errorf("expected value to be GC'd under weak storage, got '%s'", fc.String())
 	}
+
+	// WeakStorage then WithValue -> should retain value initially, but allow GC
+	fc2 := NewContent[string](
+		UseWeakStorage[string](true),
+		WithValue[string]("hello weak 2"),
+	)
+
+	if fc2.String() != "hello weak 2" {
+		t.Errorf("expected 'hello weak 2' initially, got '%s'", fc2.String())
+	}
+
+	// Since no strong references to the string should exist, GC should collect it
+	runtime.GC()
+	if fc2.String() != "" {
+		t.Errorf("expected value to be GC'd under weak storage, got '%s'", fc2.String())
+	}
 }
 
 func TestContent_WithOptions(t *testing.T) {

--- a/content_test.go
+++ b/content_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -99,6 +100,71 @@ func TestContent_EagerMemory(t *testing.T) {
 		return &b, nil
 	}), UseMemoryStorage[[]byte](true), UseEagerLoading[[]byte](true))
 	testContentImpl(t, fc, &generateCalls)
+}
+
+func TestContent_StorageOptionOrdering_Memory(t *testing.T) {
+	// WithValue before UseMemoryStorage
+	fc1 := NewContent[string](
+		WithValue[string]("hello 1"),
+		UseMemoryStorage[string](true),
+	)
+	if fc1.String() != "hello 1" {
+		t.Errorf("expected 'hello 1', got '%s'", fc1.String())
+	}
+
+	// UseMemoryStorage before WithValue
+	fc2 := NewContent[string](
+		UseMemoryStorage[string](true),
+		WithValue[string]("hello 2"),
+	)
+	if fc2.String() != "hello 2" {
+		t.Errorf("expected 'hello 2', got '%s'", fc2.String())
+	}
+}
+
+func TestContent_StorageOptionOrdering_Conflicting(t *testing.T) {
+	// Weak then Memory -> should retain value and become Memory
+	fc1 := NewContent[string](
+		WithValue[string]("hello conflict 1"),
+		UseWeakStorage[string](true),
+		UseMemoryStorage[string](true),
+	)
+	if fc1.String() != "hello conflict 1" {
+		t.Errorf("expected 'hello conflict 1', got '%s'", fc1.String())
+	}
+	// Verify it's memory store and survives GC
+	runtime.GC()
+	if fc1.String() != "hello conflict 1" {
+		t.Errorf("expected value to survive GC in MemoryStore, got '%s'", fc1.String())
+	}
+
+	// Memory then Weak -> should retain value temporarily (until GC)
+	fc2 := NewContent[string](
+		WithValue[string]("hello conflict 2"),
+		UseMemoryStorage[string](true),
+		UseWeakStorage[string](true),
+	)
+	if fc2.String() != "hello conflict 2" {
+		t.Errorf("expected 'hello conflict 2' initially, got '%s'", fc2.String())
+	}
+}
+
+func TestContent_StorageOptionOrdering_Weak(t *testing.T) {
+	// WithValue then WeakStorage -> should retain value initially, but allow GC
+	fc := NewContent[string](
+		WithValue[string]("hello weak"),
+		UseWeakStorage[string](true),
+	)
+
+	if fc.String() != "hello weak" {
+		t.Errorf("expected 'hello weak' initially, got '%s'", fc.String())
+	}
+
+	// Since no strong references to the string should exist, GC should collect it
+	runtime.GC()
+	if fc.String() != "" {
+		t.Errorf("expected value to be GC'd under weak storage, got '%s'", fc.String())
+	}
 }
 
 func TestContent_WithOptions(t *testing.T) {

--- a/content_test.go
+++ b/content_test.go
@@ -127,6 +127,10 @@ func TestContent_StorageOptionOrdering_Conflicting(t *testing.T) {
 	fc1 := NewContent[string](
 		WithValue[string]("hello conflict 1"),
 		UseWeakStorage[string](true),
+		// Force GC during intermediate state
+		func(fc *contentImpl[string]) {
+			runtime.GC()
+		},
 		UseMemoryStorage[string](true),
 	)
 	if fc1.String() != "hello conflict 1" {


### PR DESCRIPTION
Closes #18.

This PR modifies `UseWeakStorage` and `UseMemoryStorage` functional options in `content.go` so they do not indiscriminately replace `fc.store` without migrating pre-existing values (like those configured via `WithValue`). It implements a deterministic last-option-wins behaviour when conflicting storage options are supplied, preserving the value correctly. It adds relevant documentation in the README and tests demonstrating these exact semantics, including deterministic GC verification for weak storage.

---
*PR created automatically by Jules for task [5495662951190356118](https://jules.google.com/task/5495662951190356118) started by @arran4*