### PR TITLE
fix: harden helpers against concurrency and invalid config (#20, #22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Test
-        run: go test ./... -v
+        run: go test -race ./... -v
 
   go-vet:
     name: Go vet

--- a/helpers/file_modified.go
+++ b/helpers/file_modified.go
@@ -2,23 +2,30 @@ package helpers
 
 import (
 	"os"
+	"sync"
 	"time"
 )
 
 // FileModified returns a validator function that returns true as long as the specified file
 // has not been modified since the validator was created or last reset. It also returns a reset function.
+// The returned validator and reset functions are safe for concurrent use.
+// If the file is modified exactly during a reset operation, the baseline modification time
+// recorded by the reset may capture either the pre-modification or post-modification state,
+// depending on when the OS updates the file's stat metadata.
 func FileModified(filepath string) (func() bool, func()) {
+	var mu sync.RWMutex
 	var lastModified time.Time
 
 	reset := func() {
+		var newLastModified time.Time
 		info, err := os.Stat(filepath)
 		if err == nil {
-			lastModified = info.ModTime()
-		} else {
-			// If we can't stat the file initially, we assume it hasn't been modified yet
-			// or we just set a zero time.
-			lastModified = time.Time{}
+			newLastModified = info.ModTime()
 		}
+
+		mu.Lock()
+		lastModified = newLastModified
+		mu.Unlock()
 	}
 
 	reset()
@@ -29,8 +36,14 @@ func FileModified(filepath string) (func() bool, func()) {
 			// If file no longer exists or can't be accessed, we could consider it invalid
 			return false
 		}
+		modTime := info.ModTime()
+
+		mu.RLock()
+		currentLastModified := lastModified
+		mu.RUnlock()
+
 		// It's valid if it's equal or older. If it's newer, it's invalid.
-		return !info.ModTime().After(lastModified)
+		return !modTime.After(currentLastModified)
 	}
 
 	return validator, reset

--- a/helpers/file_modified_test.go
+++ b/helpers/file_modified_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -63,47 +64,48 @@ func TestFileModified_Concurrent(t *testing.T) {
 
 	isValid, reset := FileModified(tempFile)
 
-	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	startCh := make(chan struct{})
+	numWorkers := 10
+	iterations := 100
 
-	// Start goroutine validating constantly
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+	// Start goroutines validating constantly
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startCh
+			for j := 0; j < iterations; j++ {
 				isValid()
 			}
-		}
-	}()
+		}()
+	}
 
-	// Start goroutine resetting constantly
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+	// Start goroutines resetting constantly
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startCh
+			for j := 0; j < iterations; j++ {
 				reset()
 			}
-		}
-	}()
+		}()
+	}
 
-	// Start goroutine modifying file constantly
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+	// Start goroutines modifying file constantly
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startCh
+			for j := 0; j < iterations; j++ {
 				now := time.Now()
 				_ = os.Chtimes(tempFile, now, now)
-				time.Sleep(1 * time.Millisecond) // Don't overwhelm IO
 			}
-		}
-	}()
+		}()
+	}
 
-	// Let them run for a short time
-	time.Sleep(50 * time.Millisecond)
-	close(stop)
+	close(startCh)
+	wg.Wait()
 }

--- a/helpers/file_modified_test.go
+++ b/helpers/file_modified_test.go
@@ -51,3 +51,59 @@ func TestFileModified(t *testing.T) {
 		t.Error("expected validator to return false after file is deleted")
 	}
 }
+
+func TestFileModified_Concurrent(t *testing.T) {
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "test_concurrent.txt")
+
+	err := os.WriteFile(tempFile, []byte("initial"), 0644)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	isValid, reset := FileModified(tempFile)
+
+	stop := make(chan struct{})
+
+	// Start goroutine validating constantly
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				isValid()
+			}
+		}
+	}()
+
+	// Start goroutine resetting constantly
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				reset()
+			}
+		}
+	}()
+
+	// Start goroutine modifying file constantly
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				now := time.Now()
+				_ = os.Chtimes(tempFile, now, now)
+				time.Sleep(1 * time.Millisecond) // Don't overwhelm IO
+			}
+		}
+	}()
+
+	// Let them run for a short time
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+}

--- a/helpers/retry.go
+++ b/helpers/retry.go
@@ -1,13 +1,28 @@
 package helpers
 
 import (
+	"errors"
 	"time"
 )
 
 // RetryGenerator wraps a generator and retries it up to `maxRetries` times if it fails,
 // waiting `delay` between attempts.
+// If maxRetries is negative, it defaults to 0 (meaning one initial attempt and no retries).
+// If delay is negative, it defaults to 0 (no delay).
+// If gen is nil, a descriptive error is returned immediately upon invocation.
 func RetryGenerator[T any](maxRetries int, delay time.Duration, gen func() (*T, error)) func() (*T, error) {
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	if delay < 0 {
+		delay = 0
+	}
+
 	return func() (*T, error) {
+		if gen == nil {
+			return nil, errors.New("RetryGenerator: nil generator provided")
+		}
+
 		var lastErr error
 		for i := 0; i <= maxRetries; i++ {
 			val, err := gen()

--- a/helpers/retry_test.go
+++ b/helpers/retry_test.go
@@ -94,4 +94,75 @@ func TestRetryGenerator(t *testing.T) {
 			t.Errorf("expected at least %v delay, got %v", delay, elapsed)
 		}
 	})
+
+	t.Run("zero retries", func(t *testing.T) {
+		attempts := 0
+		gen := func() (*string, error) {
+			attempts++
+			return nil, errors.New("failed")
+		}
+
+		retryGen := RetryGenerator(0, 0, gen)
+		_, err := retryGen()
+		if err == nil {
+			t.Fatal("expected error, got none")
+		}
+		if attempts != 1 {
+			t.Errorf("expected 1 attempt, got %d", attempts)
+		}
+	})
+
+	t.Run("negative retries normalized to zero", func(t *testing.T) {
+		attempts := 0
+		gen := func() (*string, error) {
+			attempts++
+			return nil, errors.New("failed")
+		}
+
+		retryGen := RetryGenerator(-5, 0, gen)
+		_, err := retryGen()
+		if err == nil {
+			t.Fatal("expected error, got none")
+		}
+		if attempts != 1 {
+			t.Errorf("expected 1 attempt, got %d", attempts)
+		}
+	})
+
+	t.Run("negative delay normalized to zero", func(t *testing.T) {
+		attempts := 0
+		gen := func() (*string, error) {
+			attempts++
+			return nil, errors.New("failed")
+		}
+
+		retryGen := RetryGenerator(1, -10*time.Second, gen)
+		start := time.Now()
+		_, err := retryGen()
+		elapsed := time.Since(start)
+
+		if err == nil {
+			t.Fatal("expected error, got none")
+		}
+		if attempts != 2 {
+			t.Errorf("expected 2 attempts, got %d", attempts)
+		}
+		if elapsed > 1*time.Second {
+			t.Errorf("expected fast failure, but got elapsed time %v", elapsed)
+		}
+	})
+
+	t.Run("nil generator", func(t *testing.T) {
+		retryGen := RetryGenerator[string](3, 0, nil)
+		res, err := retryGen()
+		if err == nil {
+			t.Fatal("expected error for nil generator, got none")
+		}
+		if err.Error() != "RetryGenerator: nil generator provided" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected nil result, got %v", res)
+		}
+	})
 }

--- a/helpers/time_expiry.go
+++ b/helpers/time_expiry.go
@@ -1,20 +1,31 @@
 package helpers
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // TimeExpiry returns a validator function that returns true until the given duration has elapsed
 // since the validator was created or last reset. It also returns a reset function.
+// The returned validator and reset functions are safe for concurrent use.
 func TimeExpiry(duration time.Duration) (func() bool, func()) {
+	var mu sync.RWMutex
 	var expiry time.Time
 
 	reset := func() {
-		expiry = time.Now().Add(duration)
+		newExpiry := time.Now().Add(duration)
+		mu.Lock()
+		expiry = newExpiry
+		mu.Unlock()
 	}
 
 	reset()
 
 	validator := func() bool {
-		return time.Now().Before(expiry)
+		mu.RLock()
+		currentExpiry := expiry
+		mu.RUnlock()
+		return time.Now().Before(currentExpiry)
 	}
 
 	return validator, reset

--- a/helpers/time_expiry_test.go
+++ b/helpers/time_expiry_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -35,33 +36,35 @@ func TestTimeExpiry_Concurrent(t *testing.T) {
 	duration := 10 * time.Millisecond
 	isValid, reset := TimeExpiry(duration)
 
-	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	startCh := make(chan struct{})
+	numWorkers := 10
+	iterations := 1000
 
-	// Start goroutine validating constantly
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+	// Start goroutines validating constantly
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startCh
+			for j := 0; j < iterations; j++ {
 				isValid()
 			}
-		}
-	}()
+		}()
+	}
 
-	// Start goroutine resetting constantly
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
+	// Start goroutines resetting constantly
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startCh
+			for j := 0; j < iterations; j++ {
 				reset()
 			}
-		}
-	}()
+		}()
+	}
 
-	// Let them run for a short time
-	time.Sleep(50 * time.Millisecond)
-	close(stop)
+	close(startCh)
+	wg.Wait()
 }

--- a/helpers/time_expiry_test.go
+++ b/helpers/time_expiry_test.go
@@ -30,3 +30,38 @@ func TestTimeExpiry(t *testing.T) {
 		t.Error("expected validator to return true immediately after reset")
 	}
 }
+
+func TestTimeExpiry_Concurrent(t *testing.T) {
+	duration := 10 * time.Millisecond
+	isValid, reset := TimeExpiry(duration)
+
+	stop := make(chan struct{})
+
+	// Start goroutine validating constantly
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				isValid()
+			}
+		}
+	}()
+
+	// Start goroutine resetting constantly
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				reset()
+			}
+		}
+	}()
+
+	// Let them run for a short time
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+}


### PR DESCRIPTION
This PR hardens the `helpers` package, addressing issues #20 and #22.

Updates:
1. **TimeExpiry / FileModified Races:** Internal `sync.RWMutex` added to safely support concurrent read/reset of the closures. `FileModified` properly performs filesystem I/O outside of the critical lock region. Tests for concurrent validations vs modifications are included.
2. **RetryGenerator Invalid Arguments:** Nil generator correctly returns a descriptive error rather than panicking upon invocation. Negative values for retries and delay are normalized to zero to provide low-surprise, expected execution paths. Tests verify this zeroing behavior.

Fixes #20
Fixes #22

---
*PR created automatically by Jules for task [7266190413168262853](https://jules.google.com/task/7266190413168262853) started by @arran4*