### PR TITLE
ci: upgrade GitHub Actions workflow to canonical 043 reference

### DIFF
--- a/.github/scripts/install-git-tag-inc.sh
+++ b/.github/scripts/install-git-tag-inc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+VERSION="1.3.10"
+ARCHIVE="git-tag-inc_${VERSION}_linux_amd64.tar.gz"
+EXPECTED_SHA256="4fab8594ffff76ef99cb911baf0fe3126e4674a4fda2194d33d4f37993f82d9d"
+curl -sSfL -o "$ARCHIVE" "https://github.com/arran4/git-tag-inc/releases/download/v${VERSION}/${ARCHIVE}"
+echo "${EXPECTED_SHA256}  ${ARCHIVE}" | sha256sum -c -
+tar -xzf "$ARCHIVE" git-tag-inc
+sudo mv git-tag-inc /usr/local/bin/git-tag-inc
+rm "$ARCHIVE"
+git-tag-inc --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
   prepare-release-tag:
     name: Prepare Release Tag
     needs: [route, release-ready]
-    if: ${{ needs.route.outputs.run_release == 'true' }}
+    if: ${{ needs.route.outputs.run_release == 'true' || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -284,6 +284,7 @@ jobs:
           rm "$ARCHIVE"
           git-tag-inc --version
       - name: Verify Exact Origin/Main
+        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           GITHUB_REF_NAME: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
@@ -300,6 +301,7 @@ jobs:
             sh -c "exit 1"
           fi
       - name: Calculate or explicitly set version
+        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           RELEASE_MODE: ${{ inputs.mode }}
           RELEASE_VERSION_OVERRIDE: ${{ inputs.release_version_override }}
@@ -335,6 +337,7 @@ jobs:
           echo "Calculated TAG=$TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
       - name: Tag and push (Idempotent)
+        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           GITHUB_SHA: ${{ github.sha }}
         run: |
@@ -378,6 +381,7 @@ jobs:
              }
           fi
       - name: Dispatch Publisher
+        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,10 +256,23 @@ jobs:
     steps:
       - run: echo "All release quality gates passed."
 
+
+  smoke-git-tag-inc:
+    name: Smoke Test Installer
+    needs: [route]
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test git-tag-inc Install
+        run: .github/scripts/install-git-tag-inc.sh
+
   prepare-release-tag:
     name: Prepare Release Tag
     needs: [route, release-ready]
-    if: ${{ needs.route.outputs.run_release == 'true' || github.event_name == 'pull_request' }}
+    if: ${{ needs.route.outputs.run_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -272,19 +285,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install git-tag-inc
-        run: |
-          set -euo pipefail
-          VERSION="1.3.10"
-          ARCHIVE="git-tag-inc_${VERSION}_linux_amd64.tar.gz"
-          EXPECTED_SHA256="4fab8594ffff76ef99cb911baf0fe3126e4674a4fda2194d33d4f37993f82d9d"
-          curl -sSfL -o "$ARCHIVE" "https://github.com/arran4/git-tag-inc/releases/download/v${VERSION}/${ARCHIVE}"
-          echo "${EXPECTED_SHA256}  ${ARCHIVE}" | sha256sum -c -
-          tar -xzf "$ARCHIVE" git-tag-inc
-          sudo mv git-tag-inc /usr/local/bin/git-tag-inc
-          rm "$ARCHIVE"
-          git-tag-inc --version
+        run: .github/scripts/install-git-tag-inc.sh
       - name: Verify Exact Origin/Main
-        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           GITHUB_REF_NAME: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
@@ -301,7 +303,6 @@ jobs:
             sh -c "exit 1"
           fi
       - name: Calculate or explicitly set version
-        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           RELEASE_MODE: ${{ inputs.mode }}
           RELEASE_VERSION_OVERRIDE: ${{ inputs.release_version_override }}
@@ -337,7 +338,6 @@ jobs:
           echo "Calculated TAG=$TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
       - name: Tag and push (Idempotent)
-        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           GITHUB_SHA: ${{ github.sha }}
         run: |
@@ -381,7 +381,6 @@ jobs:
              }
           fi
       - name: Dispatch Publisher
-        if: ${{ needs.route.outputs.run_release == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,222 +1,110 @@
-# Agent rules for generation:
-# https://arran4.github.io/blog/post/2026/042-simplified-github-ci-release-safe/
-# Release safety details:
-# https://arran4.github.io/blog/post/2026/041-release-safe-single-owner-github-ci/
-# Built using these posts as reference/guidance.
+# Canonical Reference workflow. For generating/updating CI, refer to:
+# https://arran4.github.io/blog/post/2026/043-canonical-github-actions-ci-cd-super-reference/
+
 name: CI/CD
 
 on:
   push:
     branches: [main, master]
-    # semantic version tags + rc/beta snapshots
-    tags:
-      - 'v*'
-      - 'v*.*.*'
-      - 'v*.*.*-rc*'
-      - 'v*.*.*-beta*'
-      - 'test-*'
+    tags: ['v*'] # Explicit v* only to avoid test-* pushes triggering release
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       mode:
-        description: "Pipeline mode"
-        required: true
-        default: "lint-fix"
         type: choice
-        options:
-          - lint-fix
-          - build
-          - release-major
-          - release-minor
-          - release-patch
-          - release-test
-          - release-rc
-          - release-alpha
-          - monthly-maintenance
-          - publish-tag
+        default: lint-fix
+        options: [lint-fix, build, release-major, release-minor, release-patch, release-test, release-rc, release-alpha, monthly-maintenance, publish-tag]
       release_version_override:
-        description: "Optional explicit release version (for example 2.4.0 or 2.4.0-rc.2)"
-        required: false
-        default: ""
         type: string
+        default: ''
       allow_prs:
-        description: "Allow automation to open pull requests"
-        required: false
-        default: true
         type: boolean
+        default: true
   schedule:
-    # preferred heavy monthly run (quota reset strategy)
-    - cron: '17 3 1 * *'
-    # optional nightly lightweight checks
-    - cron: '41 2 * * *'
+    - cron: '0 19 1 * *'
 
+# Concurrency prevents duplicate manual releases from racing and cleans up outdated PR tests.
+# Crucially, release preparation should NOT cancel in progress to avoid aborting a cut tag.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.event.inputs.mode, 'release-') }}
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   route:
-    name: Route event
+    name: Route Event
     runs-on: ubuntu-latest
     outputs:
       run_code_checks: ${{ steps.route.outputs.run_code_checks }}
-      run_pr_meta_checks: ${{ steps.route.outputs.run_pr_meta_checks }}
       run_build: ${{ steps.route.outputs.run_build }}
-      run_cleanup: ${{ steps.route.outputs.run_cleanup }}
       run_release: ${{ steps.route.outputs.run_release }}
-      run_post_release: ${{ steps.route.outputs.run_post_release }}
-      is_monthly: ${{ steps.route.outputs.is_monthly }}
-      is_nightly: ${{ steps.route.outputs.is_nightly }}
+      run_autofix: ${{ steps.route.outputs.run_autofix }}
+      run_publisher: ${{ steps.route.outputs.run_publisher }}
+      run_maintenance: ${{ steps.route.outputs.run_maintenance }}
+      mode: ${{ steps.route.outputs.mode }}
+      profile: ${{ steps.route.outputs.profile }}
     steps:
       - id: route
-        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          REF_TYPE: ${{ github.ref_type }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-
-          run_code_checks=false
-          run_pr_meta_checks=false
-          run_build=false
-          run_cleanup=false
+          run_code_checks=true
+          run_build=true
           run_release=false
-          run_post_release=false
-          is_monthly=false
-          is_nightly=false
+          run_autofix=false
+          run_publisher=false
+          run_maintenance=false
+          mode="build"
 
-          case "${{ github.event_name }}" in
-            push)
-              run_code_checks=true
-              if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-                run_build=true
-                run_release=true
-              fi
-              ;;
-            pull_request)
-              if [[ "${{ github.event.action }}" == "closed" ]]; then
-                run_cleanup=true
-              else
-                run_pr_meta_checks=true
-                # In practice, also run code checks on PRs so lint/fmt/vet/test
-                # show up directly in the PR UI. Use concurrency to collapse churn.
-                run_code_checks=true
-              fi
-              ;;
-            release)
-              # The release already exists and is published.
-              # Never route this event back into release creation.
-              run_post_release=true
-              ;;
-            workflow_dispatch)
-              case "${{ inputs.mode }}" in
-                lint-fix)
-                  run_code_checks=true
-                  is_nightly=true
-                  ;;
-                build)
-                  run_code_checks=true
-                  run_build=true
-                  ;;
-                release-*)
-                  # A manual release mode explicitly dispatches the publisher.
-                  run_code_checks=true
-                  run_build=true
-                  run_release=true
-                  ;;
-                publish-tag)
-                  # Internal publisher dispatch mode
-                  if [[ "${{ github.ref_type }}" != "tag" || ! "${{ github.ref }}" =~ ^refs/tags/v.* ]]; then
-                    echo "publish-tag mode requires an eligible tag context (e.g. refs/tags/v*)" >&2
-                    exit 1
-                  fi
-                  run_code_checks=true
-                  run_build=true
-                  run_release=true
-                  ;;
-                monthly-maintenance)
-                  run_code_checks=true
-                  is_monthly=true
-                  ;;
-              esac
-              ;;
-            schedule)
-              run_code_checks=true
-              if [[ "${{ github.event.schedule }}" == "17 3 1 * *" ]]; then
-                is_monthly=true
-              fi
-              if [[ "${{ github.event.schedule }}" == "41 2 * * *" ]]; then
-                is_nightly=true
-              fi
-              ;;
-          esac
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # PRs just validate
+            :
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            # Ensure scheduled verification executes actual validation
+            run_maintenance=true
+            run_code_checks=true
+            run_build=true
+            mode="monthly-maintenance"
+            # If the repository configures a separate schedule for autofix (e.g., '0 4 * * *'), explicitly distinguish it here rather than defaulting all unknown schedules to autofix.
+            # if [[ "${{ github.event.schedule }}" == "0 4 * * *" ]]; then
+            #    run_autofix=true
+            #    run_maintenance=false
+            #    mode="lint-fix"
+            # fi
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            mode="${INPUT_MODE:-build}"
+            if [[ "$mode" == "lint-fix" ]]; then
+               run_autofix=true
+            elif [[ "$mode" == "publish-tag" ]]; then
+               # The internal explicit publish-tag dispatch mode
+               if [[ "$REF_TYPE" == "tag" && "$GITHUB_REF" == refs/tags/v* ]]; then
+                  run_code_checks=false
+                  run_build=false
+                  run_publisher=true
+               else
+                  echo "Error: publish-tag mode requires a v* tag context. Found: $GITHUB_REF" >&2
+                  sh -c "exit 1"
+               fi
+            elif [[ "$mode" == release-* ]]; then
+               run_release=true
+            elif [[ "$mode" == "monthly-maintenance" ]]; then
+               run_maintenance=true
+               run_code_checks=true
+               run_build=true
+            fi
+          elif [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "tag" && "$GITHUB_REF" == refs/tags/v* ]]; then
+             # Standard external v* push publication
+             run_publisher=true
+          fi
 
-          echo "run_code_checks=$run_code_checks" >> "$GITHUB_OUTPUT"
-          echo "run_pr_meta_checks=$run_pr_meta_checks" >> "$GITHUB_OUTPUT"
-          echo "run_build=$run_build" >> "$GITHUB_OUTPUT"
-          echo "run_cleanup=$run_cleanup" >> "$GITHUB_OUTPUT"
-          echo "run_release=$run_release" >> "$GITHUB_OUTPUT"
-          echo "run_post_release=$run_post_release" >> "$GITHUB_OUTPUT"
-          echo "is_monthly=$is_monthly" >> "$GITHUB_OUTPUT"
-          echo "is_nightly=$is_nightly" >> "$GITHUB_OUTPUT"
-
-  discover:
-    name: Discover capabilities and cost profile
-    needs: route
-    runs-on: ubuntu-latest
-    outputs:
-      profile: ${{ steps.profile.outputs.profile }}
-      has_go: ${{ steps.detect.outputs.has_go }}
-      has_node: ${{ steps.detect.outputs.has_node }}
-      has_dart: ${{ steps.detect.outputs.has_dart }}
-      has_flutter: ${{ steps.detect.outputs.has_flutter }}
-      has_qt_cpp: ${{ steps.detect.outputs.has_qt_cpp }}
-      has_make_c: ${{ steps.detect.outputs.has_make_c }}
-      has_docker: ${{ steps.detect.outputs.has_docker }}
-      has_goreleaser: ${{ steps.detect.outputs.has_goreleaser }}
-      has_dart_or_flutter_tests: ${{ steps.detect.outputs.has_dart_or_flutter_tests }}
-      has_packaging: ${{ steps.detect.outputs.has_packaging }}
-    steps:
-      - uses: actions/checkout@v4
-
-      # Template-time toggles (set these once for the repo; avoid broad auto-detection)
-      - id: detect
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Keep this minimal: most language choices should be decided at workflow install/customization time.
-          # Runtime checks stay for optional tests and packaging folders.
-
-          EXPECT_GO=true
-          EXPECT_NODE=false
-          EXPECT_DART=false
-          EXPECT_FLUTTER=false
-          EXPECT_QT_CPP=false
-          EXPECT_MAKE_C=false
-          EXPECT_DOCKER=false
-          EXPECT_GORELEASER=false
-
-          echo "has_go=${EXPECT_GO:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_node=${EXPECT_NODE:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_dart=${EXPECT_DART:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_flutter=${EXPECT_FLUTTER:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_qt_cpp=${EXPECT_QT_CPP:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_make_c=${EXPECT_MAKE_C:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_docker=${EXPECT_DOCKER:-false}" >> "$GITHUB_OUTPUT"
-          echo "has_goreleaser=${EXPECT_GORELEASER:-false}" >> "$GITHUB_OUTPUT"
-
-          ([[ -d test ]] || [[ -d tests ]] || [[ -f pubspec.yaml ]]) && echo "has_dart_or_flutter_tests=true" >> "$GITHUB_OUTPUT" || echo "has_dart_or_flutter_tests=false" >> "$GITHUB_OUTPUT"
-          ([[ -d packaging ]] || [[ -d pkg ]] || [[ -f debian/control ]]) && echo "has_packaging=true" >> "$GITHUB_OUTPUT" || echo "has_packaging=false" >> "$GITHUB_OUTPUT"
-
-      - id: profile
-        shell: bash
-        run: |
-          set -euo pipefail
           # repo visibility is authoritative
           if [[ "${{ github.event.repository.private }}" == "true" ]]; then
             echo "profile=private" >> "$GITHUB_OUTPUT"
@@ -224,126 +112,18 @@ jobs:
             echo "profile=public" >> "$GITHUB_OUTPUT"
           fi
 
-  prepare-release-tag:
-    name: Prepare release tag
-    needs: [route]
-    if: ${{ needs.route.outputs.run_release == 'true' }}
-    runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ steps.tag.outputs.release_tag }}
-      next_version: ${{ steps.tag.outputs.next_version }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup git-tag-inc
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode != 'publish-tag' }}
-        uses: arran4/git-tag-inc-action@v1
-        with:
-          mode: install
-      - id: tag
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "release_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            echo "next_version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          MODE="${{ inputs.mode }}"
-          OVERRIDE="${{ inputs.release_version_override }}"
-
-          if [[ "$MODE" == "publish-tag" ]]; then
-            # The publisher run doesn't compute new tags
-            echo "release_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            echo "next_version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git fetch --tags --force
-
-          if [[ -n "$OVERRIDE" ]]; then
-            # Accept "1.2.3" or "v1.2.3" override input.
-            OVERRIDE="${OVERRIDE#v}"
-            next_tag="v$OVERRIDE"
-          else
-            case "$MODE" in
-              release-major) level="major"; suffix="" ;;
-              release-minor) level="minor"; suffix="" ;;
-              release-patch) level="patch"; suffix="" ;;
-              release-test)  level="patch"; suffix="test" ;;
-              release-rc)    level="patch"; suffix="rc" ;;
-              release-alpha) level="patch"; suffix="alpha" ;;
-              *) echo "Unsupported release mode: $MODE" >&2; exit 1 ;;
-            esac
-            if command -v git-tag-inc >/dev/null 2>&1; then
-              # git-tag-inc uses positional commands (patch/major/minor/test/rc...)
-              # and NOT flag forms like -patch.
-              level="${level#-}"
-              args=(-print-version-only "$level")
-              [[ -n "$suffix" ]] && args+=("$suffix")
-              next_tag=$(git-tag-inc "${args[@]}")
-            else
-              # Fallback implementation when git-tag-inc is not available.
-              git fetch --tags --force
-              latest=$(git tag -l 'v*' | sed 's/^v//' | sort -V | tail -n 1)
-              [[ -z "$latest" ]] && latest='0.0.0'
-
-              # Prefer npx semver if available (same pattern used in g2 fixes).
-              if command -v npx >/dev/null 2>&1; then
-                case "$level" in
-                  major) bumped=$(npx --yes semver "$latest" -i major) ;;
-                  minor) bumped=$(npx --yes semver "$latest" -i minor) ;;
-                  *) bumped=$(npx --yes semver "$latest" -i patch) ;;
-                esac
-                next_tag="v${bumped}"
-              else
-                base="${latest%%-*}"
-                IFS='.' read -r maj min pat <<< "$base"
-                case "$level" in
-                  major) maj=$((maj+1)); min=0; pat=0 ;;
-                  minor) min=$((min+1)); pat=0 ;;
-                  *) pat=$((pat+1)) ;;
-                esac
-                next_tag="v${maj}.${min}.${pat}"
-              fi
-
-              if [[ -n "$suffix" ]]; then
-                next_tag="${next_tag}-${suffix}.1"
-              fi
-            fi
-          fi
-
-          # Tagging safety guards to avoid duplicate/invalid release states.
-          [[ "$next_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]] || {
-            echo "Invalid tag: $next_tag" >&2
-            exit 1
-          }
-
-          if git rev-parse "$next_tag" >/dev/null 2>&1; then
-            # Safe recovery semantics: verify existing tag against remote
-            REMOTE_TAG_SHA=$(git ls-remote --tags origin "refs/tags/$next_tag" | awk '{print $1}')
-            if [[ "$REMOTE_TAG_SHA" == "${GITHUB_SHA}" ]]; then
-              echo "Tag $next_tag exists and points to GITHUB_SHA. Safe to retry."
-            else
-              echo "Tag already exists and points to $REMOTE_TAG_SHA (expected ${GITHUB_SHA}): $next_tag" >&2
-              echo "To retry a failed publication for this exact version, ensure release_version_override is used and GITHUB_SHA matches." >&2
-              exit 1
-            fi
-          fi
-
-          echo "release_tag=$next_tag" >> "$GITHUB_OUTPUT"
-
-          clean_tag="${next_tag#v}"; clean_tag="${clean_tag%%-*}"
-          IFS='.' read -r maj min pat <<< "$clean_tag"
-          echo "next_version=${maj:-0}.${min:-0}.$(( ${pat:-0} + 1 ))-SNAPSHOT" >> "$GITHUB_OUTPUT"
+          echo "run_code_checks=$run_code_checks" >> "$GITHUB_OUTPUT"
+          echo "run_build=$run_build" >> "$GITHUB_OUTPUT"
+          echo "run_release=$run_release" >> "$GITHUB_OUTPUT"
+          echo "run_autofix=$run_autofix" >> "$GITHUB_OUTPUT"
+          echo "run_publisher=$run_publisher" >> "$GITHUB_OUTPUT"
+          echo "run_maintenance=$run_maintenance" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
 
   gitleaks:
     name: Secret scan
-    needs: [route, discover]
-    if: ${{ needs.route.outputs.run_cleanup != 'true' && (needs.route.outputs.is_nightly == 'true' || needs.route.outputs.is_monthly == 'true') }}
+    needs: [route]
+    if: ${{ needs.route.outputs.run_code_checks == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -355,31 +135,31 @@ jobs:
 
   dependency-review:
     name: Dependency review (public/full)
-    needs: [route, discover]
-    if: ${{ needs.discover.outputs.profile == 'public' && github.event_name == 'pull_request' && github.event.action != 'closed' }}
+    needs: [route]
+    if: ${{ needs.route.outputs.profile == 'public' && github.event_name == 'pull_request' && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/dependency-review-action@v4
 
   golangci:
     name: lint
-    needs: [route, discover]
-    if: ${{ needs.discover.outputs.has_go == 'true' && needs.route.outputs.run_code_checks == 'true' }}
+    needs: [route]
+    if: ${{ needs.route.outputs.run_code_checks == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
 
   go-test:
     name: Go lint/test (${{ matrix.os }})
-    needs: [route, discover, golangci]
-    if: ${{ needs.discover.outputs.has_go == 'true' && needs.route.outputs.run_code_checks == 'true' }}
+    needs: [route, golangci]
+    if: ${{ needs.route.outputs.run_code_checks == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -387,7 +167,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
@@ -396,209 +176,209 @@ jobs:
 
   go-vet:
     name: Go vet
-    needs: [route, discover]
-    if: ${{ needs.discover.outputs.has_go == 'true' && needs.route.outputs.run_code_checks == 'true' && needs.discover.outputs.profile == 'public' }}
+    needs: [route]
+    if: ${{ needs.route.outputs.run_code_checks == 'true' && needs.route.outputs.profile == 'public' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
       - run: go vet ./...
 
-  go-fmt-pr:
-    name: go fmt -> PR (manual dispatch)
-    needs: [route, discover]
-    if: ${{ needs.discover.outputs.has_go == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'lint-fix' && inputs.allow_prs == true }}
+  build:
+    name: Build Artifacts
+    needs: [route, go-test, go-vet, gitleaks]
+    if: ${{ always() && needs.route.outputs.run_build == 'true' && (needs.go-test.result == 'success' || needs.go-test.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Verify build
+        run: go build ./...
+
+  maintenance:
+    name: Monthly Maintenance (Dependency Freshness)
+    needs: [route]
+    if: ${{ needs.route.outputs.run_maintenance == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Run go fmt
-        run: go fmt ./...
-      - name: Create PR if go fmt changed files
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git diff --quiet && { echo "No fmt changes"; exit 0; }
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          BRANCH="ci/gofmt/${{ github.run_id }}"
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "ci: go fmt"
-          git push origin "$BRANCH"
-          gh pr create --title "ci: go fmt" --body "Automated go fmt from manual dispatch." --base main --head "$BRANCH" --label "ci-autofix"
+      - run: go get -u ./... && go mod tidy
+      - name: Create Pull Request
+        if: ${{ github.event_name == 'schedule' || inputs.allow_prs != false }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: monthly dependency update"
+          title: "chore: monthly dependency update"
+          branch: automation/maintenance
+          delete-branch: true
 
   autofix:
-    name: Auto-format and open PR
-    needs: [route, discover]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'lint-fix' && inputs.allow_prs == true }}
+    name: Autofix Formatting
+    needs: [route]
+    if: ${{ needs.route.outputs.run_autofix == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Go (if needed)
-        if: ${{ needs.discover.outputs.has_go == 'true' }}
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - run: go fmt ./...
+      - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - run: golangci-lint run --fix
+      - name: Create Pull Request
+        if: ${{ github.event_name == 'schedule' || inputs.allow_prs != false }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "style: auto-format code and lint fixes"
+          title: "style: auto-format code and lint fixes"
+          branch: automation/lint-fix
+          delete-branch: true
 
-      - name: Run autofix formatters
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${{ needs.discover.outputs.has_go }}" == "true" ]]; then
-            go fix ./... || true
-            go fmt ./... || true
-          fi
-
-      - name: Create PR if changes exist
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet; then
-            echo "No changes; exiting."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          PARENT_PR="${{ github.event.pull_request.number || 'none' }}"
-          BRANCH="ci/autofix/${{ github.run_id }}-parent-${PARENT_PR}"
-
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "ci: automated formatting fixes"
-          git push origin "$BRANCH"
-
-          gh pr create \
-            --title "ci: automated formatting fixes" \
-            --body "Automated formatting pass. Parent-PR: ${PARENT_PR}" \
-            --base main \
-            --head "$BRANCH" \
-            --label "ci-autofix"
-
-  cleanup-autofix-prs:
-    name: Cleanup autofix PRs on parent close
-    needs: [route]
-    if: ${{ needs.route.outputs.run_cleanup == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PARENT_PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          gh pr list --state open --search "label:ci-autofix in:title" --json number,headRefName,body | \
-            jq -r '.[] | select(.body | contains("Parent-PR: '"$PARENT_PR"'")) | [.number, .headRefName] | @tsv' | \
-            while IFS=$'\t' read -r pr branch; do
-              gh pr close "$pr" --comment "Closing auto-fix PR because parent PR #$PARENT_PR was closed."
-              git push origin --delete "$branch" || true
-            done
-
-  release-validation:
-    name: Release Validation Gate
-    needs: [route, discover, golangci, go-test, go-vet]
-    if: |
-      !failure() && !cancelled() &&
-      needs.route.result == 'success' &&
-      needs.discover.result == 'success' &&
-      (needs.discover.outputs.has_go != 'true' || needs.golangci.result == 'success') &&
-      (needs.discover.outputs.has_go != 'true' || needs.go-test.result == 'success') &&
-      (needs.discover.outputs.has_go != 'true' || needs.go-vet.result == 'success')
+  release-ready:
+    name: Release Quality Gates Passed
+    needs: [route, go-test, go-vet, golangci, gitleaks, build]
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Validation complete"
+      - run: echo "All release quality gates passed."
 
-  release-context:
-    name: Release Context
-    needs: [route, prepare-release-tag, release-validation]
-    if: ${{ !failure() && !cancelled() && needs.route.outputs.run_release == 'true' }}
+  prepare-release-tag:
+    name: Prepare Release Tag
+    needs: [route, release-ready]
+    if: ${{ needs.route.outputs.run_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       actions: write
-    outputs:
-      release_tag: ${{ steps.export.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Normalize and push tag
-        id: export
-        shell: bash
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install git-tag-inc
+        uses: arran4/git-tag-inc-action@v1
+        with:
+          mode: install
+      - name: Verify Exact Origin/Main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_REF_NAME: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-
-          TAG="${{ needs.prepare-release-tag.outputs.release_tag }}"
-          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
-
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            exit 0
+          if [[ "$GITHUB_REF_NAME" != "refs/heads/main" ]]; then
+            echo "Error: Manual release preparation must run on refs/heads/main, got $GITHUB_REF_NAME"
+            sh -c "exit 1"
           fi
-
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.mode }}" == "publish-tag" ]]; then
-            if [[ "${{ github.ref_type }}" != "tag" ]]; then
-              echo "Error: publish-tag mode invoked on a non-tag ref." >&2
-              exit 1
-            fi
-            echo "Running in internal publisher mode; tag is immutable context."
-            exit 0
+          git fetch origin main
+          MAIN_SHA=$(git rev-parse origin/main)
+          if [[ "$MAIN_SHA" != "$GITHUB_SHA" ]]; then
+            echo "Error: Requested release against $GITHUB_SHA but origin/main is at $MAIN_SHA"
+            sh -c "exit 1"
           fi
-
-          git fetch --tags --force
-          REMOTE_TAG_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" | awk '{print $1}')
-
-          if [[ -n "$REMOTE_TAG_SHA" ]]; then
-            if [[ "$REMOTE_TAG_SHA" == "${GITHUB_SHA}" ]]; then
-              echo "Tag $TAG already exists on remote and points to the correct SHA. Continuing safely."
-            else
-              echo "Tag $TAG already exists on remote but points to a different commit ($REMOTE_TAG_SHA). Failing." >&2
-              exit 1
-            fi
+      - name: Calculate or explicitly set version
+        env:
+          RELEASE_MODE: ${{ inputs.mode }}
+          RELEASE_VERSION_OVERRIDE: ${{ inputs.release_version_override }}
+        run: |
+          set -euo pipefail
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          if [[ -n "$RELEASE_VERSION_OVERRIDE" ]]; then
+             # Normalize optional leading v
+             TAG="${RELEASE_VERSION_OVERRIDE#v}"
+             TAG="v${TAG}"
+             echo "Using manual version override: $TAG"
+             # Validate shape
+             if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+                echo "Error: Override $TAG is not a valid release tag shape."
+                sh -c "exit 1"
+             fi
           else
-            git tag "$TAG" "${GITHUB_SHA}"
-            git push origin "$TAG" || (
-              VERIFY_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" | awk '{print $1}')
-              if [[ "$VERIFY_SHA" == "${GITHUB_SHA}" ]]; then
-                echo "Tag successfully verified on remote after push error."
-              else
-                echo "Tag push failed and remote verification failed." >&2
-                exit 1
-              fi
-            )
+             echo "Using arran4/git-tag-inc..."
+             # Use git-tag-inc safe version calculation
+             case "$RELEASE_MODE" in
+               release-major) level="major"; suffix="" ;;
+               release-minor) level="minor"; suffix="" ;;
+               release-patch) level="patch"; suffix="" ;;
+               release-test)  level="patch"; suffix="test" ;;
+               release-rc)    level="patch"; suffix="rc" ;;
+               release-alpha) level="patch"; suffix="alpha" ;;
+               *) echo "Unsupported release mode: $RELEASE_MODE" >&2; sh -c "exit 1" ;;
+             esac
+             args=(--print-version-only "$level")
+             [[ -n "$suffix" ]] && args+=("$suffix")
+             TAG="$(git-tag-inc "${args[@]}")"
+          fi
+          echo "Calculated TAG=$TAG"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+      - name: Tag and push (Idempotent)
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Check remote state for idempotency/retry
+          REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" | grep -v '{}$' | awk '{print $1}' || true)
+          # Also check peeled annotated tag if it exists
+          PEELED_SHA=$(git ls-remote --tags origin "refs/tags/$TAG^{}" | awk '{print $1}' || true)
+          if [[ -n "$PEELED_SHA" ]]; then
+              REMOTE_SHA="$PEELED_SHA"
           fi
 
-          # Explicitly dispatch the publisher workflow at the new tag ref
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            gh workflow run "ci.yml" --ref "$TAG" -f mode="publish-tag"
-          fi
+          if [[ -n "$REMOTE_SHA" ]]; then
+             if [[ "$REMOTE_SHA" == "$GITHUB_SHA" ]]; then
+                echo "Tag $TAG already exists on origin and points to correct SHA ($GITHUB_SHA). Safely retrying publish."
+             else
+                echo "Error: Tag $TAG already exists on origin but points to $REMOTE_SHA, not expected $GITHUB_SHA."
+                sh -c "exit 1"
+             fi
+          else
+             # Final race guard: verify origin/main is STILL exactly GITHUB_SHA right before tagging
+             git fetch origin main
+             CURRENT_MAIN_SHA=$(git rev-parse origin/main)
+             if [[ "$CURRENT_MAIN_SHA" != "$GITHUB_SHA" ]]; then
+                echo "Race condition: origin/main advanced to $CURRENT_MAIN_SHA before tagging"
+                sh -c "exit 1"
+             fi
 
-  github-release:
-    name: Publish GitHub release
-    needs: [route, discover, release-context]
-    if: ${{ !failure() && !cancelled() && needs.route.outputs.run_release == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+             # If local tag exists but wasn't pushed, delete to recreate fresh
+             git tag -d "$TAG" 2>/dev/null || true
+
+             # Create and push the tag
+             git tag "$TAG"
+             git push origin "$TAG" || {
+                # Race safe remote verification
+                REMOTE_SHA=$(git ls-remote --tags origin "$TAG" | awk '{print $1}')
+                if [[ "$REMOTE_SHA" != "$GITHUB_SHA" ]]; then
+                   echo "Race condition: tag pushed remotely with different SHA ($REMOTE_SHA)"
+                   sh -c "exit 1"
+                fi
+             }
+          fi
+      - name: Dispatch Publisher
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run ci.yml --ref "$TAG" -f mode=publish-tag
+
+  publisher:
+    name: Release Publisher
+    needs: [route, release-ready]
+    if: ${{ needs.route.outputs.run_publisher == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -607,22 +387,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Create release with generated notes + discussion
+      - name: Create release with generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.release-context.outputs.release_tag }}
         run: |
           set -euo pipefail
+          # The tag is simply github.ref_name for standard push v* or publish-tag modes.
+          TAG="${{ github.ref_name }}"
           prerelease=""
           if [[ "$TAG" == *-rc* || "$TAG" == *-alpha* || "$TAG" == *-beta* || "$TAG" == *-test* ]]; then
             prerelease="--prerelease"
           fi
-
           discussion_arg="--discussion-category Announcements"
-
           # Permissions/discussions can block discussion linking in some repos.
-          # Fall back to plain release creation if category linking fails.
           if [[ -n "$prerelease" ]]; then
             gh release create "$TAG" --generate-notes $prerelease
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,8 +274,15 @@ jobs:
       - name: Install git-tag-inc
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/arran4/git-tag-inc/releases/download/v1.3.10/git-tag-inc-linux-amd64" -o /usr/local/bin/git-tag-inc
-          chmod +x /usr/local/bin/git-tag-inc
+          VERSION="1.3.10"
+          ARCHIVE="git-tag-inc_${VERSION}_linux_amd64.tar.gz"
+          EXPECTED_SHA256="4fab8594ffff76ef99cb911baf0fe3126e4674a4fda2194d33d4f37993f82d9d"
+          curl -sSfL -o "$ARCHIVE" "https://github.com/arran4/git-tag-inc/releases/download/v${VERSION}/${ARCHIVE}"
+          echo "${EXPECTED_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          tar -xzf "$ARCHIVE" git-tag-inc
+          sudo mv git-tag-inc /usr/local/bin/git-tag-inc
+          rm "$ARCHIVE"
+          git-tag-inc --version
       - name: Verify Exact Origin/Main
         env:
           GITHUB_REF_NAME: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,10 @@ jobs:
     if: ${{ needs.route.outputs.run_code_checks == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -147,12 +147,12 @@ jobs:
     if: ${{ needs.route.outputs.run_code_checks == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -166,8 +166,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -180,8 +180,8 @@ jobs:
     if: ${{ needs.route.outputs.run_code_checks == 'true' && needs.route.outputs.profile == 'public' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -193,8 +193,8 @@ jobs:
     if: ${{ always() && needs.route.outputs.run_build == 'true' && (needs.go-test.result == 'success' || needs.go-test.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Verify build
@@ -209,14 +209,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go get -u ./... && go mod tidy
       - name: Create Pull Request
         if: ${{ github.event_name == 'schedule' || inputs.allow_prs != false }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: monthly dependency update"
           title: "chore: monthly dependency update"
@@ -232,8 +232,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go fmt ./...
@@ -241,7 +241,7 @@ jobs:
       - run: golangci-lint run --fix
       - name: Create Pull Request
         if: ${{ github.event_name == 'schedule' || inputs.allow_prs != false }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "style: auto-format code and lint fixes"
           title: "style: auto-format code and lint fixes"
@@ -265,10 +265,10 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Install git-tag-inc
@@ -384,7 +384,7 @@ jobs:
       contents: write
       discussions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Create release with generated notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,9 +272,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install git-tag-inc
-        uses: arran4/git-tag-inc-action@v1
-        with:
-          mode: install
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/arran4/git-tag-inc/releases/download/v1.3.10/git-tag-inc-linux-amd64" -o /usr/local/bin/git-tag-inc
+          chmod +x /usr/local/bin/git-tag-inc
       - name: Verify Exact Origin/Main
         env:
           GITHUB_REF_NAME: ${{ github.ref }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 run:
   timeout: 5m
 
@@ -7,3 +8,8 @@ linters:
     - staticcheck
     - errcheck
     - ineffassign
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-version: "2"
 run:
   timeout: 5m
 
@@ -8,8 +7,3 @@ linters:
     - staticcheck
     - errcheck
     - ineffassign
-  exclusions:
-    presets:
-      - comments
-      - common-false-positives
-      - legacy


### PR DESCRIPTION
This PR updates `.github/workflows/ci.yml` using the latest canonical CI generation specification (043), explicitly simplifying the routing logic and cleaning up older 041/042 paradigms. The workflow maintains all necessary Go linting, vetting, testing, and secret scanning requirements while implementing the canonical simplified routing job and proper race-condition safe tag handling. It drops the stale `release` trigger and implements the unified manual `workflow_dispatch` design as required by the specification. Actionlint validation and repository tests have successfully passed.

---
*PR created automatically by Jules for task [8510269124182665414](https://jules.google.com/task/8510269124182665414) started by @arran4*